### PR TITLE
Change sql encoding

### DIFF
--- a/backend/SQL
+++ b/backend/SQL
@@ -15,7 +15,7 @@ DROP SCHEMA IF EXISTS `mydb` ;
 -- -----------------------------------------------------
 -- Schema mydb
 -- -----------------------------------------------------
-CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8 ;
+CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8mb4 ;
 USE `mydb` ;
 
 -- -----------------------------------------------------


### PR DESCRIPTION
There is a quirk with the `utf8` encoding in MySQL, because it cannot support certain characters including emojis. The `utf8mb4` encoding does support the entire Unicode character set, and therefore is able to store all emojis. More specifically, UTF-8 is a variable-length encoding of a max of 4 bytes, but the `utf8` encoding can only contain 3 bytes. `utf8mb4` can contain 4 bytes.