### PR TITLE
CI - Change "npm install" to "npm ci"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         cache-dependency-path: app/package-lock.json
     - name: Build
       run: |
-        npm install
+        npm ci
         npm run build
       working-directory: app
   prettier:


### PR DESCRIPTION
This changes `npm install` in the GitHub action to `npm ci`. This prevents it from updating packages, enabling a more reproducible build and saves a few seconds.