### PR TITLE
Change coordinate data types to floating point

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -9,8 +9,8 @@ export interface Vendor {
   BusinessHours: string;
   Phone: string;
   BusinessLogo: string;
-  Latitude: string;
-  Longitude: string;
+  Latitude: number;
+  Longitude: number;
 }
 
 export interface User {

--- a/backend/database.go
+++ b/backend/database.go
@@ -32,8 +32,8 @@ type Vendor struct {
 	BusinessHours   string
 	Phone           string
 	BusinessLogo    string
-	Latitude        string
-	Longitude       string
+	Latitude        float32
+	Longitude       float32
 }
 
 func (d *Database) VendorCreate(vendor *Vendor) error {


### PR DESCRIPTION
I noticed that the coordinate types (longitude and latitude) are floating point inside the database, but they are strings elsewhere. I corrected them all to be floating point.