### PR TITLE
Store credentials and retrieve credentials in API slice

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -123,12 +123,18 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ["Review"],
     }),
-    newToken: builder.mutation<Token, Credentials>({
-      query: (credentials) => ({
-        url: "/token",
-        method: "POST",
-        body: credentials,
-      }),
+    getTokenAndSetState: builder.mutation<undefined, Credentials>({
+      queryFn: async (args, api, extraOptions) => {
+        let response = await fetch("http://localhost:8080/token", {
+          method: "POST",
+          body: JSON.stringify(args),
+        });
+        if (!response.ok) {
+          return { error: await response.json() };
+        }
+
+        return { data: await response.json() };
+      },
     }),
   }),
 });
@@ -142,5 +148,5 @@ export const {
   useUpdatePasswordMutation,
   useReviewsQuery,
   useSubmitReviewMutation,
-  useNewTokenMutation,
+  useGetTokenAndSetStateMutation,
 } = apiSlice;

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -133,7 +133,9 @@ export const apiSlice = createApi({
           return { error: await response.json() };
         }
 
-        return { data: await response.json() };
+        api.dispatch({ type: "root/setToken", payload: await response.json() });
+
+        return { data: undefined };
       },
     }),
   }),

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -123,8 +123,8 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ["Review"],
     }),
-    getTokenAndSetState: builder.mutation<undefined, Credentials>({
-      queryFn: async (args, api, extraOptions) => {
+    setCredentialsAndGetToken: builder.mutation<undefined, Credentials>({
+      queryFn: async (args, api) => {
         let response = await fetch("http://localhost:8080/token", {
           method: "POST",
           body: JSON.stringify(args),
@@ -135,11 +135,27 @@ export const apiSlice = createApi({
 
         api.dispatch({ type: "root/setToken", payload: await response.json() });
 
+        setCredentialsState(args);
+
         return { data: undefined };
       },
     }),
   }),
 });
+
+function setCredentialsState(credentials: Credentials) {
+  console.info("set localStorage");
+  localStorage.setItem("user", JSON.stringify(credentials));
+}
+
+function getCredentials(): Credentials | null {
+  const entry = localStorage.getItem("user");
+  if (entry === null) {
+    return null;
+  }
+
+  return JSON.parse(entry);
+}
 
 export const {
   useVendorQuery,
@@ -150,5 +166,5 @@ export const {
   useUpdatePasswordMutation,
   useReviewsQuery,
   useSubmitReviewMutation,
-  useGetTokenAndSetStateMutation,
+  useSetCredentialsAndGetTokenMutation,
 } = apiSlice;

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -54,16 +54,18 @@ export type Token = string;
 const encode = encodeURIComponent;
 
 export const apiSlice = createApi({
-  baseQuery: fetchBaseQuery({
-    baseUrl: "http://localhost:8080",
-    prepareHeaders: (headers, { getState }) => {
-      const token = (getState() as RootState).root.token;
-      if (token) {
-        headers.set("Authorization", `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: async (args, api, extraOptions) => {
+    return fetchBaseQuery({
+      baseUrl: "http://localhost:8080",
+      prepareHeaders: (headers, { getState }) => {
+        const token = (getState() as RootState).root.token;
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+        return headers;
+      },
+    })(args, api, extraOptions);
+  },
   tagTypes: ["Review", "LoggedInUser"],
   endpoints: (builder) => ({
     vendor: builder.query<Vendor, string>({

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -40,11 +40,8 @@ export default function Login(): React.ReactElement {
   // }, []);
 
   const onSubmit = async () => {
-    try {
-      const token = await getToken(credentials).unwrap();
-      dispatch(setToken(token));
-      navigate("/");
-    } catch (e) {}
+    await getToken(credentials);
+    navigate("/");
   };
 
   const storeCredentials = () => {

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -4,7 +4,10 @@ import Buttons from "../Atoms/Button/Buttons";
 import HeaderBar from "../Molecules/HeaderBar/HeaderBar";
 import styles from "./login.module.css";
 import { Grid } from "semantic-ui-react";
-import { Credentials, useGetTokenAndSetStateMutation } from "../../../api";
+import {
+  Credentials,
+  useSetCredentialsAndGetTokenMutation,
+} from "../../../api";
 import { setToken, useAppDispatch, useAppSelector } from "../../../store";
 import { useNavigate } from "react-router-dom";
 
@@ -17,7 +20,7 @@ export default function Login(): React.ReactElement {
     Password: "",
     Username: "",
   });
-  const [getToken] = useGetTokenAndSetStateMutation();
+  const [setCredentialsMutation] = useSetCredentialsAndGetTokenMutation();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const error = useAppSelector((state) => state.root.error);
@@ -40,7 +43,7 @@ export default function Login(): React.ReactElement {
   // }, []);
 
   const onSubmit = async () => {
-    await getToken(credentials);
+    await setCredentialsMutation(credentials);
     navigate("/");
   };
 

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -4,7 +4,7 @@ import Buttons from "../Atoms/Button/Buttons";
 import HeaderBar from "../Molecules/HeaderBar/HeaderBar";
 import styles from "./login.module.css";
 import { Grid } from "semantic-ui-react";
-import { Credentials, useNewTokenMutation } from "../../../api";
+import { Credentials, useGetTokenAndSetStateMutation } from "../../../api";
 import { setToken, useAppDispatch, useAppSelector } from "../../../store";
 import { useNavigate } from "react-router-dom";
 
@@ -17,31 +17,31 @@ export default function Login(): React.ReactElement {
     Password: "",
     Username: "",
   });
-  const [newToken] = useNewTokenMutation();
+  const [getToken] = useGetTokenAndSetStateMutation();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const error = useAppSelector((state) => state.root.error);
 
-  useEffect(() => {
-    async function generateNewToken() {
-      try {
-        if (localStorage.getItem("user")) {
-          let obj = JSON.parse(localStorage.getItem("user")!);
-          const token = await newToken({
-            Password: obj.password,
-            Username: obj.username,
-          }).unwrap();
-          dispatch(setToken(token));
-        }
-      } catch (error) {}
-    }
-
-    generateNewToken();
-  }, []);
+  // useEffect(() => {
+  //   async function generateNewToken() {
+  //     try {
+  //       if (localStorage.getItem("user")) {
+  //         let obj = JSON.parse(localStorage.getItem("user")!);
+  //         const token = await getToken({
+  //           Password: obj.password,
+  //           Username: obj.username,
+  //         }).unwrap();
+  //         dispatch(setToken(token));
+  //       }
+  //     } catch (error) {}
+  //   }
+  //
+  //   generateNewToken();
+  // }, []);
 
   const onSubmit = async () => {
     try {
-      const token = await newToken(credentials).unwrap();
+      const token = await getToken(credentials).unwrap();
       dispatch(setToken(token));
       navigate("/");
     } catch (e) {}

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -21,40 +21,12 @@ export default function Login(): React.ReactElement {
     Username: "",
   });
   const [setCredentialsMutation] = useSetCredentialsAndGetTokenMutation();
-  const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const error = useAppSelector((state) => state.root.error);
-
-  // useEffect(() => {
-  //   async function generateNewToken() {
-  //     try {
-  //       if (localStorage.getItem("user")) {
-  //         let obj = JSON.parse(localStorage.getItem("user")!);
-  //         const token = await getToken({
-  //           Password: obj.password,
-  //           Username: obj.username,
-  //         }).unwrap();
-  //         dispatch(setToken(token));
-  //       }
-  //     } catch (error) {}
-  //   }
-  //
-  //   generateNewToken();
-  // }, []);
 
   const onSubmit = async () => {
     await setCredentialsMutation(credentials);
     navigate("/");
-  };
-
-  const storeCredentials = () => {
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        username: credentials.Username,
-        password: credentials.Password,
-      })
-    );
   };
 
   return (
@@ -94,7 +66,7 @@ export default function Login(): React.ReactElement {
                 {/*  <Checkbox label="I agree to the Terms and Conditions" />*/}
                 {/*</Form.Field>*/}
                 <Container>
-                  <Buttons login color="green" clicked={storeCredentials}>
+                  <Buttons login color="green">
                     Login
                   </Buttons>
                 </Container>

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -14,9 +14,7 @@ const apiErrorHandler: Middleware =
   (next) =>
   (action) => {
     if (isRejectedWithValue(action)) {
-      api.dispatch(
-        setError(new Error(`api error: ${JSON.stringify(action.payload)}`))
-      );
+      api.dispatch(setError(`api error: ${JSON.stringify(action.payload)}`));
     }
     return next(action);
   };
@@ -24,11 +22,11 @@ const apiErrorHandler: Middleware =
 export const rootSlice = createSlice({
   name: "root",
   initialState: {
-    error: null as Error | null,
+    error: null as string | null,
     token: null as string | null,
   },
   reducers: {
-    setError: (state, { payload }: PayloadAction<Error>) => {
+    setError: (state, { payload }: PayloadAction<string>) => {
       console.error(payload);
       state.error = payload;
     },

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -4,6 +4,7 @@ import {
   isRejectedWithValue,
   Middleware,
   MiddlewareAPI,
+  PayloadAction,
 } from "@reduxjs/toolkit";
 import { apiSlice } from "./api";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
@@ -13,7 +14,9 @@ const apiErrorHandler: Middleware =
   (next) =>
   (action) => {
     if (isRejectedWithValue(action)) {
-      api.dispatch(setError(`api error: ${JSON.stringify(action.payload)}`));
+      api.dispatch(
+        setError(new Error(`api error: ${JSON.stringify(action.payload)}`))
+      );
     }
     return next(action);
   };
@@ -25,11 +28,11 @@ export const rootSlice = createSlice({
     token: null as string | null,
   },
   reducers: {
-    setError: (state, { payload }) => {
+    setError: (state, { payload }: PayloadAction<Error>) => {
       console.error(payload);
       state.error = payload;
     },
-    setToken: (state, { payload }) => {
+    setToken: (state, { payload }: PayloadAction<string>) => {
       state.token = payload;
     },
   },

--- a/backend/api.go
+++ b/backend/api.go
@@ -273,7 +273,7 @@ func (a *API) TokenPost(c *gin.Context) {
 	claims := TokenClaims{
 		UserID: userID,
 		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: (time.Now().Add(time.Minute * 10)).Unix(),
+			ExpiresAt: (time.Now().Add(time.Minute*10 + time.Second*5)).Unix(),
 		},
 	}
 


### PR DESCRIPTION
The `setCredentialsAndGetToken` reducer stores credentials to localStorage, and all queries retrieve the credentials to get a new token on each query. The code to do this in `Login.tsx` is moved to the API slice so that it is executed for every page that needs access to the API.

It currently generates a new token on every query, even if they occur 1 second after another, so it is not optimal. Later, I will add a timestamp to the state so that it knows when it needs to refresh the token (and when it can use the current token).