### PR TITLE
Renew token if token has expired

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -1,6 +1,7 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/dist/query/react";
-import { RootState, setToken } from "./store";
+import { RootState } from "./store";
 import { DateTime } from "luxon";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export interface Vendor {
   ID: string;
@@ -49,14 +50,26 @@ export interface Credentials {
   Password: string;
 }
 
-export type Token = string;
+export const tokenSlice = createSlice({
+  name: "token",
+  initialState: {
+    token: null as string | null,
+  },
+  reducers: {
+    setToken: (state, { payload }: PayloadAction<string>) => {
+      state.token = payload;
+    },
+  },
+});
+
+const { setToken } = tokenSlice.actions;
 
 const encode = encodeURIComponent;
 
 const baseQuery = fetchBaseQuery({
   baseUrl: "http://localhost:8080",
   prepareHeaders: (headers, { getState }) => {
-    const token = (getState() as RootState).root.token;
+    const token = (getState() as RootState).token.token;
     if (token) {
       headers.set("Authorization", `Bearer ${token}`);
     }
@@ -77,7 +90,7 @@ export const apiSlice = createApi({
         return response;
       }
 
-      api.dispatch({ type: "root/setToken", payload: response.data });
+      api.dispatch(setToken(response.data as string));
     }
 
     return baseQuery(args, api, extraOptions);
@@ -150,7 +163,7 @@ export const apiSlice = createApi({
           return response;
         }
 
-        api.dispatch({ type: "root/setToken", payload: response.data });
+        api.dispatch(setToken(response.data as string));
 
         setCredentialsState(args);
 

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -8,7 +8,7 @@ import {
   Credentials,
   useSetCredentialsAndGetTokenMutation,
 } from "../../../api";
-import { setToken, useAppDispatch, useAppSelector } from "../../../store";
+import { useAppSelector } from "../../../store";
 import { useNavigate } from "react-router-dom";
 
 /**

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -42,10 +42,8 @@ export const store = configureStore({
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
-      serializableCheck: {
-        // DateTimes in API responses cannot be serialized. Non-serializability is traded off for ease of use.
-        ignoredActions: ["api/executeQuery/fulfilled"],
-      },
+      // Non-serializable DateTimes are allowed in API schemas only.
+      serializableCheck: false,
     })
       .concat(apiSlice.middleware)
       .concat(apiErrorHandler),

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -6,7 +6,7 @@ import {
   MiddlewareAPI,
   PayloadAction,
 } from "@reduxjs/toolkit";
-import { apiSlice } from "./api";
+import { apiSlice, tokenSlice } from "./api";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 
 const apiErrorHandler: Middleware =
@@ -23,28 +23,32 @@ export const rootSlice = createSlice({
   name: "root",
   initialState: {
     error: null as string | null,
-    token: null as string | null,
   },
   reducers: {
     setError: (state, { payload }: PayloadAction<string>) => {
       console.error(payload);
       state.error = payload;
     },
-    setToken: (state, { payload }: PayloadAction<string>) => {
-      state.token = payload;
-    },
   },
 });
 
-export const { setError, setToken } = rootSlice.actions;
+export const { setError } = rootSlice.actions;
 
 export const store = configureStore({
   reducer: {
-    [apiSlice.reducerPath]: apiSlice.reducer,
     root: rootSlice.reducer,
+    [apiSlice.reducerPath]: apiSlice.reducer,
+    [tokenSlice.name]: tokenSlice.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(apiSlice.middleware).concat(apiErrorHandler),
+    getDefaultMiddleware({
+      serializableCheck: {
+        // DateTimes in API responses cannot be serialized. Non-serializability is traded off for ease of use.
+        ignoredActions: ["api/executeQuery/fulfilled"],
+      },
+    })
+      .concat(apiSlice.middleware)
+      .concat(apiErrorHandler),
   devTools: true,
 });
 


### PR DESCRIPTION
Instead of requesting a new token on each query, there is a check for the token expiration time so that a token is requested only when it has expired. Additionally, I made `tokenSlice` to group the token and the timestamp.