### PR TITLE
Add deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy
 on:
   push:
-    branches:
-      - 'deployment'
     tags:
       - '*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - 'deployment'
+    tags:
+      - '*'
+
+jobs:
+  deploy_gh_pages:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '17.1'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+      - run: |
+          npm ci
+          npm run build
+        working-directory: app
+      - uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          BRANCH: gh-pages
+          FOLDER: app/dist

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@
   - Open your browser and go to http://localhost:8080/. If it says "404 page not found", it's working.
 2. Go to the `app` folder, and install dependencies with `npm i`
 3. Do `npm start` and wait for it to compile
-4. With the backend server still running, go to http://localhost:3000/
+4. With the backend server still running, go to http://localhost:3000/streetfoodlove/
   - Press ctrl-c to stop the server and npm

--- a/app/public/404.html
+++ b/app/public/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/app/public/404.html
+++ b/app/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Single Page Apps for GitHub Pages</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
@@ -26,15 +26,25 @@
 
       var l = window.location;
       l.replace(
-        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
-        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-        l.hash
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
       );
-
     </script>
   </head>
-  <body>
-  </body>
+  <body></body>
 </html>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -14,22 +14,28 @@
     />
 
     <script type="text/javascript">
-      if (window.location.pathname === '/') {
-		  window.location = '/streetfoodlove/';
+      if (window.location.pathname === "/") {
+        window.location = "/streetfoodlove/";
       }
 
       // For resolving paths
       // https://github.com/rafgraph/spa-github-pages
-      (function(l) {
-        if (l.search[1] === '/' ) {
-          var decoded = l.search.slice(1).split('&').map(function(s) {
-            return s.replace(/~and~/g, '&')
-          }).join('?');
-          window.history.replaceState(null, null,
-              l.pathname.slice(0, -1) + decoded + l.hash
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash
           );
         }
-      }(window.location))
+      })(window.location);
     </script>
   </head>
   <body>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -12,6 +12,22 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.1/dist/semantic.min.css"
     />
+
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -10,7 +10,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.1/dist/semantic.min.css"
+      href="https://unpkg.com/semantic-ui@2.4.1/dist/semantic.min.css"
     />
 
     <script type="text/javascript">

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -14,8 +14,11 @@
     />
 
     <script type="text/javascript">
-      // Single Page Apps for GitHub Pages
-      // MIT License
+      if (window.location.pathname === '/') {
+		  window.location = '/streetfoodlove/';
+      }
+
+      // For resolving paths
       // https://github.com/rafgraph/spa-github-pages
       (function(l) {
         if (l.search[1] === '/' ) {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,7 +14,7 @@ function App(): React.ReactElement {
   return (
     <ErrorBoundary>
       <Provider store={store}>
-        <BrowserRouter>
+        <BrowserRouter basename="/streetfoodlove">
           <Routes>
             <Route path="/" element={<LandingPage />} />
             <Route path="/vendors/:ID" element={<Vendor />} />

--- a/app/webpack/webpack.common.js
+++ b/app/webpack/webpack.common.js
@@ -30,7 +30,10 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({ template: "./public/index.html" }),
     new CopyPlugin({
-      patterns: [{ from: "public", to: "public" }],
+      patterns: [
+        { from: "public", to: "public" },
+        { from: "public/404.html", to: "404.html" },
+      ],
     }),
   ],
 };

--- a/app/webpack/webpack.prod.js
+++ b/app/webpack/webpack.prod.js
@@ -14,7 +14,7 @@ module.exports = merge(common, {
           loader: "babel-loader",
           options: {
             presets: [
-              "@babel/react",
+              ["@babel/react", { runtime: "automatic" }],
               "@babel/preset-typescript",
               ["@babel/preset-env", { targets: "last 2 years" }],
             ],


### PR DESCRIPTION
This adds a deployment workflow which is triggered by pushing a tag. The workflow updates the files on GitHub pages. The `404.html` file saves the URL and redirects to `index.html` which reads the URL to restore the correct page. You can view the deployed webpage here: https://bcfoodapp.github.io/streetfoodlove/. Of course, none of the API functions work right now.

From now on, the local development URL is http://localhost:3000/streetfoodlove/ because the `basename` of `BrowserRouter` had to be changed. I made it so that http://localhost:3000/ will redirect to the correct URL.