### PR TITLE
Add tsc command to CI, add SignUpDate property

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         npm ci
         npm run typescript
+        npm run build
       working-directory: app
   prettier:
     name: Prettier

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   webpack:
-    name: Webpack
+    name: Typescript
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
@@ -24,7 +24,7 @@ jobs:
     - name: Build
       run: |
         npm ci
-        npm run build
+        npm run typescript
       working-directory: app
   prettier:
     name: Prettier

--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "webpack serve --config webpack/webpack.dev.js",
     "build": "webpack --config webpack/webpack.prod.js",
+    "typescript": "tsc -p tsconfig.json",
     "prettier": "prettier -w ."
   },
   "dependencies": {

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -5,6 +5,7 @@ import styles from "./accountformgroup.module.css";
 import { UserProtected, useUpdateUserMutation } from "../../../../api";
 import { v4 as uuid } from "uuid";
 import { UserType } from "../../../../api";
+import { DateTime } from "luxon";
 
 const AccountSettingsFormGroup: React.FC<{
   disabled: boolean;
@@ -25,6 +26,7 @@ const AccountSettingsFormGroup: React.FC<{
       FirstName: firstName,
       LastName: lastName,
       UserType: UserType.Customer,
+      SignUpDate: DateTime.now(),
     });
     alert("Updated User Settings!");
   };

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
It turns out babel-loader can't catch all compiler errors, so tsc, the typescript compiler, is added to CI. The necessary `SignUpDate` property is added to `UserProtected`.