### PR TITLE
Make vendor website optional

### DIFF
--- a/app/src/components/UI/Pages/CreateVendorPage.tsx
+++ b/app/src/components/UI/Pages/CreateVendorPage.tsx
@@ -49,7 +49,7 @@ const CreateVendorPage: React.FC = () => {
     businessAddress: Yup.string().required("Required"),
     phoneNumber: Yup.string().required("Required"),
     businessHours: Yup.string().required("Required"),
-    website: Yup.string().required("Required"),
+    website: Yup.string(),
   });
 
   const onSubmit = (data: inputValues) => {
@@ -181,7 +181,6 @@ const CreateVendorPage: React.FC = () => {
                 onBlur={handleBlur}
                 error={touched.website && Boolean(errors.website)}
                 value={values.website}
-                required
               />
               <ErrorMessage
                 name="website"

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -73,7 +73,7 @@ export default function VendorAppForm(): React.ReactElement {
   const validationSchema = Yup.object({
     name: Yup.string().required("Required"),
     businessAddress: Yup.string().required("Required"),
-    website: Yup.string().required("Required"),
+    website: Yup.string(),
     fromHour: Yup.string().required("Required"),
     toHour: Yup.string().required("Required"),
     phoneNumber: Yup.string().required("Required"),
@@ -142,7 +142,6 @@ export default function VendorAppForm(): React.ReactElement {
                 fluid
                 label="Website URL"
                 placeholder="Website URL"
-                required
                 width={5}
                 name={"website"}
                 onChange={handleChange}


### PR DESCRIPTION
This changes the form schema and input design so that the website field for `CreateVendorPage` is made optional. Not all vendors have their own website and/or social media.