### PR TITLE
Add test for reset_database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,8 @@ jobs:
     - name: Prettier
       run: npx prettier --check .
       working-directory: app
-  build:
-    name: Compile server
+  test-backend:
+    name: Run backend tests
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -52,9 +52,13 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - name: Compile server
-        run: go build .
-        working-directory: backend
+      - name: Setup MySQL
+        run: |
+          sudo systemctl start mysql.service
+          mysql --user=root --password=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED BY ''"
+      - name: reset_database test
+        run: go test
+        working-directory: backend/reset_database
   golint:
     name: Lint Go
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
+      - name: Compile server
+        run: go build .
+        working-directory: backend
       - name: Setup MySQL
         run: |
           sudo systemctl start mysql.service

--- a/backend/reset_database/main.go
+++ b/backend/reset_database/main.go
@@ -65,7 +65,7 @@ func SetupTables(db *sqlx.DB) error {
 	commands := [...]string{
 		`
 		CREATE TABLE IF NOT EXISTS Vendor (
-			ID CHAR(36) NOT NULL,
+			ID CHAR(36) NOT NULL
 			Name VARCHAR(100) NOT NULL,
 			BusinessAddress VARCHAR(500) NULL,
 			Website VARCHAR(500) NULL,

--- a/backend/reset_database/main.go
+++ b/backend/reset_database/main.go
@@ -65,7 +65,7 @@ func SetupTables(db *sqlx.DB) error {
 	commands := [...]string{
 		`
 		CREATE TABLE IF NOT EXISTS Vendor (
-			ID CHAR(36) NOT NULL
+			ID CHAR(36) NOT NULL,
 			Name VARCHAR(100) NOT NULL,
 			BusinessAddress VARCHAR(500) NULL,
 			Website VARCHAR(500) NULL,

--- a/backend/reset_database/main_test.go
+++ b/backend/reset_database/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+)
+
+// Ensures that all SQL commands have no syntax errors.
+func TestResetDatabase(t *testing.T) {
+	defer func() {
+		if e := recover(); e != nil {
+			t.Fatal(e)
+		}
+	}()
+
+	main()
+}


### PR DESCRIPTION
This test simply runs reset_database to make sure there are no SQL syntax errors. The test is added to the CI run.