### PR TITLE
Make sign up forms redirect after submission

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -35,7 +35,7 @@ function App(): React.ReactElement {
           <Route path="/account-profile" element={<AccountProfile />} />
           <Route path="/your-acct-user" element={<YourAccountUser />} />
           <Route path="/business-guide" element={<BusinessGuides />} />
-          <Route path="vendor-dashboard" element={<VendorDashBoard />} />
+          <Route path="/vendor-dashboard" element={<VendorDashBoard />} />
           <Route path="/edit-vendor-page" element={<EditVendorPage />} />
           <Route path="/guides/:ID" element={<BusinessGuideArticle />} />
         </Routes>

--- a/app/src/components/UI/Molecules/HeaderBar/HeaderBar.tsx
+++ b/app/src/components/UI/Molecules/HeaderBar/HeaderBar.tsx
@@ -62,7 +62,7 @@ export default function HeaderBar(): React.ReactElement {
         ) : null}
         {token === null ? (
           <Menu.Item>
-            <Link to="/signup">
+            <Link to="/account-selection">
               <Buttons signup>Sign Up</Buttons>
             </Link>
             <Link to="/login">

--- a/app/src/components/UI/Pages/AccountSelection.tsx
+++ b/app/src/components/UI/Pages/AccountSelection.tsx
@@ -10,20 +10,20 @@ const AccountSelection: React.FC = () => {
     <Container className={styles.wrapper}>
       <h2>Choose Account Type</h2>
       <Container className={styles.selectBox}>
-        <Container className={styles.customerBox}>
-          <h3>Customer</h3>
-          <Link to={"/signup"}>
+        <Link to="/signup">
+          <Container className={styles.customerBox}>
+            <h3>Customer</h3>
             <Icon name="arrow right" className={styles.icon} size="large" />
-          </Link>
-        </Container>
-        <Container className={styles.vendorBox}>
-          <h3>
-            Vendor <i>(for business)</i>
-          </h3>
-          <Link to={"/signup"}>
+          </Container>
+        </Link>
+        <Link to="/signup?usertype=vendor">
+          <Container className={styles.vendorBox}>
+            <h3>
+              Vendor <i>(for business)</i>
+            </h3>
             <Icon name="arrow right" className={styles.icon} size="large" />
-          </Link>
-        </Container>
+          </Container>
+        </Link>
       </Container>
     </Container>
   );

--- a/app/src/components/UI/Pages/Signup.tsx
+++ b/app/src/components/UI/Pages/Signup.tsx
@@ -1,15 +1,13 @@
 import React from "react";
-import { Form, Container } from "semantic-ui-react";
+import { Container, Form } from "semantic-ui-react";
 import Buttons from "../Atoms/Button/Buttons";
 import styles from "./signup.module.css";
 import { useCreateUserMutation, UserType } from "../../../api";
 import { v4 as uuid } from "uuid";
 import { DateTime } from "luxon";
-import { Formik, FormikProps, ErrorMessage, Field } from "formik";
+import { ErrorMessage, Field, Formik, FormikProps } from "formik";
 import * as Yup from "yup";
-import { useAppSelector } from "../../../store";
-import MessageError from "../Atoms/Message/MessageError";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 interface inputValues {
   firstName: string;
@@ -23,6 +21,11 @@ interface inputValues {
 export default function Signup(): React.ReactElement {
   const [createUser, { isSuccess }] = useCreateUserMutation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  let userType = UserType.Customer;
+  if (searchParams.get("usertype") === "vendor") {
+    userType = UserType.Vendor;
+  }
 
   const initialValues: inputValues = {
     firstName: "",
@@ -47,7 +50,7 @@ export default function Signup(): React.ReactElement {
       ID: uuid(),
       Username: data.username,
       Photo: uuid(),
-      UserType: UserType.Customer,
+      UserType: userType,
       Email: data.email,
       FirstName: data.firstName,
       LastName: data.lastName,
@@ -57,7 +60,11 @@ export default function Signup(): React.ReactElement {
   };
 
   if (isSuccess) {
-    navigate("/");
+    if (userType === UserType.Customer) {
+      navigate("/");
+    } else {
+      navigate("/vendor-signup");
+    }
   }
 
   return (

--- a/app/src/components/UI/Pages/Signup.tsx
+++ b/app/src/components/UI/Pages/Signup.tsx
@@ -9,6 +9,7 @@ import { Formik, FormikProps, ErrorMessage, Field } from "formik";
 import * as Yup from "yup";
 import { useAppSelector } from "../../../store";
 import MessageError from "../Atoms/Message/MessageError";
+import { useNavigate } from "react-router-dom";
 
 interface inputValues {
   firstName: string;
@@ -20,7 +21,8 @@ interface inputValues {
 }
 
 export default function Signup(): React.ReactElement {
-  const [createUser] = useCreateUserMutation();
+  const [createUser, { isSuccess }] = useCreateUserMutation();
+  const navigate = useNavigate();
 
   const initialValues: inputValues = {
     firstName: "",
@@ -40,8 +42,8 @@ export default function Signup(): React.ReactElement {
     agreedConditions: Yup.bool().oneOf([true], "Required"),
   });
 
-  const onSubmit = async (data: inputValues) => {
-    await createUser({
+  const onSubmit = (data: inputValues) => {
+    createUser({
       ID: uuid(),
       Username: data.username,
       Photo: uuid(),
@@ -52,9 +54,11 @@ export default function Signup(): React.ReactElement {
       Password: data.password,
       SignUpDate: DateTime.now(),
     });
-    // TODO need better feedback, and show any errors if they occurred
-    alert("created account");
   };
+
+  if (isSuccess) {
+    navigate("/");
+  }
 
   return (
     <Container className={styles.signUpWrapper}>

--- a/app/src/components/UI/Pages/Signup.tsx
+++ b/app/src/components/UI/Pages/Signup.tsx
@@ -19,7 +19,7 @@ interface inputValues {
 }
 
 export default function Signup(): React.ReactElement {
-  const [createUser, { isSuccess }] = useCreateUserMutation();
+  const [createUser] = useCreateUserMutation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   let userType = UserType.Customer;
@@ -45,8 +45,8 @@ export default function Signup(): React.ReactElement {
     agreedConditions: Yup.bool().oneOf([true], "Required"),
   });
 
-  const onSubmit = (data: inputValues) => {
-    createUser({
+  const onSubmit = async (data: inputValues) => {
+    const result = await createUser({
       ID: uuid(),
       Username: data.username,
       Photo: uuid(),
@@ -57,15 +57,15 @@ export default function Signup(): React.ReactElement {
       Password: data.password,
       SignUpDate: DateTime.now(),
     });
-  };
 
-  if (isSuccess) {
-    if (userType === UserType.Customer) {
-      navigate("/");
-    } else {
-      navigate("/vendor-signup");
+    if ((result as any).error === undefined) {
+      if (userType === UserType.Customer) {
+        navigate("/");
+      } else {
+        navigate("/vendor-signup");
+      }
     }
-  }
+  };
 
   return (
     <Container className={styles.signUpWrapper}>

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -24,9 +24,9 @@ interface inputValues {
 
 export default function VendorAppForm(): React.ReactElement {
   const navigate = useNavigate();
-  const [createVendor, { isSuccess }] = useCreateVendorMutation();
+  const [createVendor] = useCreateVendorMutation();
 
-  const onSubmit = (data: inputValues) => {
+  const onSubmit = async (data: inputValues) => {
     const vendor: Vendor = {
       ID: uuid(),
       Name: data.name,
@@ -38,12 +38,11 @@ export default function VendorAppForm(): React.ReactElement {
       Latitude: 0,
       Longitude: 0,
     };
-    createVendor(vendor);
+    const result = await createVendor(vendor);
+    if ((result as any).error === undefined) {
+      navigate("/vendor-dashboard");
+    }
   };
-
-  if (isSuccess) {
-    navigate("/vendor-dashboard");
-  }
 
   const timeOptionsFromValues = [
     //options for business hours starting from...

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -8,6 +8,7 @@ import { Formik, FormikProps, ErrorMessage, Field } from "formik";
 import * as Yup from "yup";
 import { useAppSelector } from "../../../store";
 import MessageError from "../Atoms/Message/MessageError";
+import { useNavigate } from "react-router-dom";
 
 interface inputValues {
   name: string;
@@ -20,7 +21,16 @@ interface inputValues {
 }
 
 export default function VendorAppForm(): React.ReactElement {
-  const storeUserInfo = () => {};
+  const navigate = useNavigate();
+
+  const onSubmit = () => {
+    // TODO submit data
+  };
+
+  // TODO replace with isSuccess status
+  if (false) {
+    navigate("/vendor-dashboard");
+  }
 
   const timeOptionsFromValues = [
     //options for business hours starting from...
@@ -88,7 +98,7 @@ export default function VendorAppForm(): React.ReactElement {
 
       <Formik
         enableReinitialize
-        onSubmit={storeUserInfo}
+        onSubmit={onSubmit}
         validateOnChange={true}
         initialValues={initialValues}
         validationSchema={validationSchema}

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -24,7 +24,7 @@ interface inputValues {
 
 export default function VendorAppForm(): React.ReactElement {
   const navigate = useNavigate();
-  const [createVendor] = useCreateVendorMutation();
+  const [createVendor, { isSuccess }] = useCreateVendorMutation();
 
   const onSubmit = (data: inputValues) => {
     const vendor: Vendor = {
@@ -39,11 +39,9 @@ export default function VendorAppForm(): React.ReactElement {
       Longitude: 0,
     };
     createVendor(vendor);
-    // TODO navigate to vendor page
   };
 
-  // TODO replace with isSuccess status
-  if (false) {
+  if (isSuccess) {
     navigate("/vendor-dashboard");
   }
 


### PR DESCRIPTION
Closes https://github.com/bcfoodapp/streetfoodlove/issues/164.

The sign up flow should go like this:

1. It starts from `/account-selection`. For both customer and vendor sign up, go to `/signup`.
2. `signup`: Uses URL parameter to determine which customer type to create. On submission, go to `/` for customers or `/vendor-signup` for vendors.
3. `/vendor-signup`: On submission, go to `/vendor-dashboard`.