### PR TITLE
Remove username field in AccountSettingsFormGroup

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -267,17 +267,14 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ["Review"],
     }),
-    // Retrieves token using stored credentials and saves it to state if token state is null.
-    getToken: builder.query<undefined, void>({
+    // Gets token using stored credentials and saves it to state. Returns null if credentials are not stored.
+    getToken: builder.query<string | null, void>({
       queryFn: async (arg, api, extraOptions) => {
         const credentials = getCredentials();
         if (credentials !== null) {
-          const result = await getAndSaveCredentials(credentials, api);
-          if (result) {
-            return { error: result };
-          }
+          return getAndSaveCredentials(credentials, api);
         }
-        return { data: undefined };
+        return { data: null };
       },
     }),
     // Retrieves token and stores credentials and name in localStorage.

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -9,19 +9,21 @@ import {
   useUserProtectedQuery,
 } from "../../../../api";
 import { UserType } from "../../../../api";
-import { useAppSelector, useAppDispatch } from "../../../../store";
-import jwtDecode from "jwt-decode";
+import { useAppSelector } from "../../../../store";
 
-const AccountSettings: React.FC<{
-  token: string;
+const AccountSettingsFormGroup: React.FC<{
   disabled: boolean;
   setDisabledForm: (value: boolean) => void;
-}> = ({ token, disabled, setDisabledForm }) => {
+}> = ({ disabled, setDisabledForm }) => {
   useGetTokenQuery();
+  const token = useAppSelector((state) => state.token.token);
+  if (token === null) {
+    return <p>Not logged in</p>;
+  }
+
   const userID = getUserIDFromToken(token);
   const userQuery = useUserProtectedQuery(userID);
   const user = userQuery.data;
-  const dispatch = useAppDispatch();
 
   const [email, setEmail] = useState("");
   const [firstName, setFirstName] = useState("");
@@ -40,8 +42,6 @@ const AccountSettings: React.FC<{
   const [updateSetting] = useUpdateUserMutation();
 
   const handleSubmit = async () => {
-    // dispatch(setName({ firstName: firstName, lastName: lastName }));
-    // user is defined when handleSubmit is called
     await updateSetting({
       ID: userID,
       Photo: user!.Photo,
@@ -99,24 +99,6 @@ const AccountSettings: React.FC<{
         </Container>
       </Form>
     </Container>
-  );
-};
-
-const AccountSettingsFormGroup: React.FC<{
-  disabled: boolean;
-  setDisabledForm: (value: boolean) => void;
-}> = ({ disabled, setDisabledForm }) => {
-  const token = useAppSelector((state) => state.token.token);
-  if (token === null) {
-    return <p>Not logged in</p>;
-  }
-
-  return (
-    <AccountSettings
-      token={token}
-      disabled={disabled}
-      setDisabledForm={setDisabledForm}
-    />
   );
 };
 

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -30,14 +30,12 @@ const AccountSettingsFormGroup: React.FC<{
   const [email, setEmail] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
-  const [username, setUsername] = useState("");
 
   useEffect(() => {
     if (userQueryIsSuccess) {
       setEmail(user!.Email);
       setFirstName(user!.FirstName);
       setLastName(user!.LastName);
-      setUsername(user!.Username);
     }
   }, [userQueryIsSuccess]);
 
@@ -45,7 +43,7 @@ const AccountSettingsFormGroup: React.FC<{
     const response = await updateSetting({
       ID: userID,
       Photo: user!.Photo,
-      Username: username,
+      Username: user!.Username,
       Email: email,
       FirstName: firstName,
       LastName: lastName,
@@ -85,15 +83,6 @@ const AccountSettingsFormGroup: React.FC<{
             disabled={disabled}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-          />
-        </Form.Group>
-        <Form.Group>
-          <Form.Input
-            label="Username"
-            placeholder="Username"
-            disabled={disabled}
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
           />
         </Form.Group>
         <Container className={styles.saveBtn}>

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -14,16 +14,17 @@ const AccountSettingsFormGroup: React.FC<{
   disabled: boolean;
   setDisabledForm: (value: boolean) => void;
 }> = ({ disabled, setDisabledForm }) => {
-  const { data: token, isSuccess } = useGetTokenQuery();
+  const { data: token, isSuccess: tokenIsSuccess } = useGetTokenQuery();
 
   let userID = "";
-  if (isSuccess && token !== null) {
+  if (tokenIsSuccess && token !== null) {
     userID = getUserIDFromToken(token as string);
   }
-  const { data: user, isSuccess: userQueryIsSuccess } = useUserProtectedQuery(
-    userID,
-    { skip: userID === "" }
-  );
+  const {
+    data: user,
+    isSuccess: userQueryIsSuccess,
+    isLoading: userQueryIsLoading,
+  } = useUserProtectedQuery(userID, { skip: userID === "" });
 
   const [updateSetting] = useUpdateUserMutation();
 
@@ -55,7 +56,7 @@ const AccountSettingsFormGroup: React.FC<{
     }
   };
 
-  if (isSuccess && token === null) {
+  if (tokenIsSuccess && token === null) {
     return <p>Not logged in</p>;
   }
 
@@ -69,6 +70,7 @@ const AccountSettingsFormGroup: React.FC<{
             disabled={disabled}
             value={firstName}
             onChange={(e) => setFirstName(e.target.value)}
+            loading={userQueryIsLoading}
           />
           <Form.Input
             label="Last Name"
@@ -76,6 +78,7 @@ const AccountSettingsFormGroup: React.FC<{
             disabled={disabled}
             value={lastName}
             onChange={(e) => setLastName(e.target.value)}
+            loading={userQueryIsLoading}
           />
           <Form.Input
             label="Email"
@@ -83,6 +86,7 @@ const AccountSettingsFormGroup: React.FC<{
             disabled={disabled}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            loading={userQueryIsLoading}
           />
         </Form.Group>
         <Container className={styles.saveBtn}>

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -42,7 +42,7 @@ const AccountSettingsFormGroup: React.FC<{
   }, [userQueryIsSuccess]);
 
   const handleSubmit = async () => {
-    await updateSetting({
+    const response = await updateSetting({
       ID: userID,
       Photo: user!.Photo,
       Username: username,
@@ -52,7 +52,9 @@ const AccountSettingsFormGroup: React.FC<{
       UserType: UserType.Customer,
       SignUpDate: user!.SignUpDate,
     });
-    alert("Updated User Settings!");
+    if ((response as any).error === undefined) {
+      alert("Updated User Settings!");
+    }
   };
 
   if (isSuccess && token === null) {

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -198,7 +198,6 @@ func (d *Database) UserUpdate(user *UserProtected) error {
 			Username = :Username,
 			FirstName = :FirstName,
 			LastName = :LastName,
-			SignUpDate = :SignUpDate,
 			UserType = :UserType,
 			Photo = :Photo
 		WHERE ID = :ID


### PR DESCRIPTION
Closes https://github.com/bcfoodapp/streetfoodlove/issues/173.

This removes the username field. When the username is changed, the stored credentials become invalid. Although we can force the user to log in again, this complicates the code and it's better to not allow username changes.

The `SignUpDate` column is made read-only by removing it from the `UPDATE` command.

Query chains in `AccountSettingsFormGroup` are cleaned up using the `skip` parameter for queries.