### PR TITLE
Hide error when location changes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,10 +18,9 @@ import MessageError from "./components/UI/Atoms/Message/MessageError";
 import LoginWrapper from "./components/UI/Pages/Login";
 
 function App(): React.ReactElement {
-  const error = useAppSelector((state) => state.root.error);
   return (
     <ErrorBoundary>
-      {error ? <MessageError errorMsg={error.toString()} /> : null}
+      <MessageError />
       <BrowserRouter basename="/streetfoodlove">
         <HeaderBar />
         <Routes>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -20,8 +20,8 @@ import LoginWrapper from "./components/UI/Pages/Login";
 function App(): React.ReactElement {
   return (
     <ErrorBoundary>
-      <MessageError />
       <BrowserRouter basename="/streetfoodlove">
+        <MessageError />
         <HeaderBar />
         <Routes>
           <Route path="/" element={<LandingPage />} />

--- a/app/src/components/UI/Atoms/Message/MessageError.tsx
+++ b/app/src/components/UI/Atoms/Message/MessageError.tsx
@@ -1,12 +1,18 @@
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import { Container, Message } from "semantic-ui-react";
 import styles from "./msgerror.module.css";
 import { hideError, useAppDispatch, useAppSelector } from "../../../../store";
+import { useLocation } from "react-router-dom";
 
 const MessageError: React.FC = () => {
   const error = useAppSelector((state) => state.root.error);
   const showError = useAppSelector((state) => state.root.showError);
   const dispatch = useAppDispatch();
+  const location = useLocation();
+
+  useEffect(() => {
+    dispatch(hideError());
+  }, [location]);
 
   const dismissHandler = () => {
     dispatch(hideError());

--- a/app/src/components/UI/Atoms/Message/MessageError.tsx
+++ b/app/src/components/UI/Atoms/Message/MessageError.tsx
@@ -1,11 +1,13 @@
-import React, { useState, MouseEvent } from "react";
-import { Container, Message, MessageProps } from "semantic-ui-react";
+import React, { useState } from "react";
+import { Container, Message } from "semantic-ui-react";
 import styles from "./msgerror.module.css";
+import { useAppSelector } from "../../../../store";
 
-const MessageError: React.FC<{ errorMsg: string }> = ({ errorMsg }) => {
-  const [visibleMsg, setVisibleMsg] = useState<boolean>(true);
+const MessageError: React.FC = () => {
+  const error = useAppSelector((state) => state.root.error);
+  const [visibleMsg, setVisibleMsg] = useState(true);
 
-  const dismissHandler = (e: MouseEvent<HTMLElement>, data: MessageProps) => {
+  const dismissHandler = () => {
     setVisibleMsg(false);
   };
 
@@ -15,7 +17,7 @@ const MessageError: React.FC<{ errorMsg: string }> = ({ errorMsg }) => {
         <Message negative className={styles.msg} onDismiss={dismissHandler}>
           <Message.Header>Error</Message.Header>
           <Message.List>
-            <Message.Item>{errorMsg}</Message.Item>
+            <Message.Item>{error}</Message.Item>
           </Message.List>
         </Message>
       ) : null}

--- a/app/src/components/UI/Atoms/Message/MessageError.tsx
+++ b/app/src/components/UI/Atoms/Message/MessageError.tsx
@@ -1,19 +1,20 @@
 import React, { useState } from "react";
 import { Container, Message } from "semantic-ui-react";
 import styles from "./msgerror.module.css";
-import { useAppSelector } from "../../../../store";
+import { hideError, useAppDispatch, useAppSelector } from "../../../../store";
 
 const MessageError: React.FC = () => {
   const error = useAppSelector((state) => state.root.error);
-  const [visibleMsg, setVisibleMsg] = useState(true);
+  const showError = useAppSelector((state) => state.root.showError);
+  const dispatch = useAppDispatch();
 
   const dismissHandler = () => {
-    setVisibleMsg(false);
+    dispatch(hideError());
   };
 
   return (
     <Container className={styles.wrapper}>
-      {visibleMsg ? (
+      {showError ? (
         <Message negative className={styles.msg} onDismiss={dismissHandler}>
           <Message.Header>Error</Message.Header>
           <Message.List>

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -31,12 +31,14 @@ export default function Login(): React.ReactElement {
   });
 
   const onSubmit = async (values: inputValues) => {
-    await setCredentialsMutation({
+    const response = await setCredentialsMutation({
       Username: values.Username,
       Password: values.Password,
     });
 
-    navigate("/");
+    if ((response as any).error === undefined) {
+      navigate("/");
+    }
   };
 
   return (

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -23,16 +23,21 @@ export const rootSlice = createSlice({
   name: "root",
   initialState: {
     error: null as string | null,
+    showError: false,
   },
   reducers: {
     setError: (state, { payload }: PayloadAction<string>) => {
       console.error(payload);
       state.error = payload;
+      state.showError = true;
+    },
+    hideError: (state) => {
+      state.showError = false;
     },
   },
 });
 
-export const { setError } = rootSlice.actions;
+export const { setError, hideError } = rootSlice.actions;
 
 export const store = configureStore({
   reducer: {


### PR DESCRIPTION
This PR makes the error message close when the page changes. To facilitate this, the `showError` state is moved to the app state.

Also, the login only redirects if response is a success.