### PR TITLE
Remove async attribute from Google API script

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -13,7 +13,7 @@
       href="https://unpkg.com/semantic-ui@2.4.1/dist/semantic.min.css"
     />
     <!-- For Google sign-in -->
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://accounts.google.com/gsi/client"></script>
 
     <script type="text/javascript">
       if (window.location.pathname === "/") {


### PR DESCRIPTION
While the `async` attribute for the script tag has its benefits, it was causing issues when calls to Google were happening before the script fully loaded.