### PR TITLE
Add POST /token/google route

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -264,7 +264,9 @@ type Credentials struct {
 
 func (d *Database) UserIDByCredentials(credentials *Credentials) (uuid.UUID, error) {
 	const command = `
-		SELECT ID, LoginPassword FROM User WHERE Username=?
+		SELECT ID, LoginPassword
+		FROM User
+		WHERE Username=?
 	`
 	row := d.db.QueryRowx(command, &credentials.Username)
 
@@ -282,6 +284,20 @@ func (d *Database) UserIDByCredentials(credentials *Credentials) (uuid.UUID, err
 	}
 
 	return userID, nil
+}
+
+func (d *Database) UserIDByGoogleID(googleID string) (uuid.UUID, error) {
+	const command = `
+		SELECT ID
+		FROM User
+		WHERE GoogleID=?
+	`
+
+	row := d.db.QueryRowx(command, &googleID)
+
+	userID := uuid.UUID{}
+	err := row.Scan(&userID)
+	return userID, err
 }
 
 type Review struct {

--- a/backend/reset_database/main.go
+++ b/backend/reset_database/main.go
@@ -75,7 +75,7 @@ func SetupTables(db *sqlx.DB) error {
 			LoginPassword BINARY(32) NULL,
 			UserType TINYINT NULL,
 			Photo CHAR(36) NOT NULL,
-			GoogleID VARCHAR(50) NULL,
+			GoogleID VARCHAR(50) UNIQUE NULL,
 			PRIMARY KEY (ID)
 		)
 		`,


### PR DESCRIPTION
`POST /token/google` inputs a Google token and returns an app token for the user with the corresponding Google ID. According to my design proposal, this should be the only additional route necessary to enable Google sign-in.