### PR TITLE
Change getToken to a mutation endpoint

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -286,9 +286,9 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ["Review"],
     }),
-    // Gets token using stored credentials and saves it to state. Returns null if credentials are not stored.
-    // This should be used to get the token if no query is called before the token is required. When any query is used,
-    // the token can be retrieved from the store.
+    // Gets token using stored credentials and saves it to state.
+    // This endpoint should be used to get the token if no query is called before the token is required. When any query
+    // is called, the token can be retrieved from the store without calling getToken.
     getToken: builder.mutation<undefined, void>({
       queryFn: async (arg, api, extraOptions) => {
         const credentials = getCredentialsAndName();

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -289,13 +289,13 @@ export const apiSlice = createApi({
     // Gets token using stored credentials and saves it to state. Returns null if credentials are not stored.
     // This should be used to get the token if no query is called before the token is required. When any query is used,
     // the token can be retrieved from the store.
-    getToken: builder.query<string | null, void>({
+    getToken: builder.mutation<undefined, void>({
       queryFn: async (arg, api, extraOptions) => {
         const credentials = getCredentialsAndName();
         if (credentials !== null) {
-          return getAndSaveCredentials(credentials, api);
+          await getAndSaveCredentials(credentials, api);
         }
-        return { data: null };
+        return { data: undefined };
       },
     }),
     // Retrieves token and stores credentials and name in localStorage.
@@ -379,7 +379,7 @@ export const {
   useUpdatePasswordMutation,
   useReviewsQuery,
   useSubmitReviewMutation,
-  useGetTokenQuery,
+  useGetTokenMutation,
   useSetCredentialsAndGetTokenMutation,
   useMapViewVendorsQuery,
   useGuideQuery,

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -4,17 +4,22 @@ import Buttons from "../../Atoms/Button/Buttons";
 import styles from "./accountformgroup.module.css";
 import {
   getUserIDFromToken,
-  useGetTokenQuery,
+  useGetTokenMutation,
   useUpdateUserMutation,
   useUserProtectedQuery,
 } from "../../../../api";
 import { UserType } from "../../../../api";
+import { useAppSelector } from "../../../../store";
 
 const AccountSettingsFormGroup: React.FC<{
   disabled: boolean;
   setDisabledForm: (value: boolean) => void;
 }> = ({ disabled, setDisabledForm }) => {
-  const { data: token, isSuccess: tokenIsSuccess } = useGetTokenQuery();
+  const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
+  useEffect(() => {
+    getToken();
+  }, []);
+  const token = useAppSelector((state) => state.token.token);
 
   let userID = "";
   if (tokenIsSuccess && token !== null) {

--- a/app/src/components/UI/Pages/EditVendorPage.tsx
+++ b/app/src/components/UI/Pages/EditVendorPage.tsx
@@ -10,7 +10,7 @@ import Buttons from "../Atoms/Button/Buttons";
 import styles from "./createvendorpage.module.css";
 import {
   getUserIDFromToken,
-  useGetTokenQuery,
+  useGetTokenMutation,
   useUpdateVendorMutation,
   useVendorByOwnerIDQuery,
   Vendor,
@@ -18,6 +18,7 @@ import {
 import { Formik, FormikProps, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import React, { useEffect, useState } from "react";
+import { useAppSelector } from "../../../store";
 
 const fileInput = () => {
   return <Input type="file" className={styles.input} size="small" fluid />;
@@ -41,7 +42,11 @@ const businessHours = [
 const EditVendorPage: React.FC = () => {
   const [updateVendor, { isLoading: updateVendorIsLoading }] =
     useUpdateVendorMutation();
-  const { data: token, isSuccess: tokenIsSuccess } = useGetTokenQuery();
+  const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
+  useEffect(() => {
+    getToken();
+  }, []);
+  const token = useAppSelector((state) => state.token.token);
 
   let userID = "";
   if (tokenIsSuccess && token !== null) {

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Form, Container } from "semantic-ui-react";
 import Buttons from "../Atoms/Button/Buttons";
 import { Dropdown } from "semantic-ui-react";
@@ -8,11 +8,12 @@ import * as Yup from "yup";
 import {
   getUserIDFromToken,
   useCreateVendorMutation,
-  useGetTokenQuery,
+  useGetTokenMutation,
   Vendor,
 } from "../../../api";
 import { v4 as uuid } from "uuid";
 import { useNavigate } from "react-router-dom";
+import { useAppSelector } from "../../../store";
 
 interface inputValues {
   name: string;
@@ -27,7 +28,11 @@ interface inputValues {
 export default function VendorAppForm(): React.ReactElement {
   const navigate = useNavigate();
   const [createVendor] = useCreateVendorMutation();
-  const { data: token, isSuccess: tokenIsSuccess } = useGetTokenQuery();
+  const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
+  useEffect(() => {
+    getToken();
+  }, []);
+  const token = useAppSelector((state) => state.token.token);
 
   if (!tokenIsSuccess || token === null) {
     return <p>Not logged in</p>;
@@ -35,9 +40,10 @@ export default function VendorAppForm(): React.ReactElement {
 
   const onSubmit = async (data: inputValues) => {
     if (!tokenIsSuccess || token === null) {
+      // Button is inaccessible when token is null
       throw new Error("unexpected");
     }
-    const userID = getUserIDFromToken(token as string);
+    const userID = getUserIDFromToken(token as unknown as string);
     const vendor: Vendor = {
       ID: uuid(),
       Name: data.name,

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -43,7 +43,7 @@ export default function VendorAppForm(): React.ReactElement {
       // Button is inaccessible when token is null
       throw new Error("unexpected");
     }
-    const userID = getUserIDFromToken(token as unknown as string);
+    const userID = getUserIDFromToken(token);
     const vendor: Vendor = {
       ID: uuid(),
       Name: data.name,


### PR DESCRIPTION
Closes https://github.com/bcfoodapp/streetfoodlove/issues/210.

This changes `getToken` to a mutation endpoint to avoid caching. Tokens cannot be cached as it expires after a period of time.