### PR TITLE
Fix displayed rating in FinalStarRating

### DIFF
--- a/app/src/components/UI/Atoms/StarRating/FinalStarRating.tsx
+++ b/app/src/components/UI/Atoms/StarRating/FinalStarRating.tsx
@@ -16,13 +16,7 @@ export const FinalStarRating = ({ starRating }: Props) => {
   }
   return (
     <Container className={styles.rate}>
-      <Rating
-        maxRating={5}
-        defaultRating={rating}
-        icon="star"
-        size="huge"
-        disabled
-      />
+      <Rating maxRating={5} rating={rating} icon="star" size="huge" disabled />
     </Container>
   );
 };


### PR DESCRIPTION
I found that `FinalStarRating` exhibited a bug where the submitted review was not showing the correct rating. This was due to it not updating its rating component when the rating changed. Using the `rating` attribute ensures it is updated when the value changes.