### PR TITLE
Improve getToken mutation

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -13,6 +13,7 @@ import {
 import jwtDecode from "jwt-decode";
 import config from "./configuration.json";
 import { v4 as uuid } from "uuid";
+import { DependencyList, useEffect } from "react";
 
 export interface Vendor {
   ID: string;
@@ -344,16 +345,16 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ["Review"],
     }),
-    // Gets token using stored credentials and saves it to state.
-    // This endpoint should be used to get the token if no query is called before the token is required. When any query
-    // is called, the token can be retrieved from the store without calling getToken.
-    getToken: builder.mutation<undefined, void>({
+    // Gets token using stored credentials and saves it to state. Returns token if credentials are stored, otherwise
+    // returns null. This endpoint should be used to get the token if no query is called before the token is required.
+    // When any query is called, the token can be retrieved from the store without calling getToken.
+    getToken: builder.mutation<string | null, void>({
       queryFn: async (arg, api, extraOptions) => {
         const credentials = getCredentialsEntry();
-        if (credentials !== null) {
-          await getAndSaveCredentials(credentials, api);
+        if (credentials === null) {
+          return { data: null };
         }
-        return { data: undefined };
+        return await getAndSaveCredentials(credentials, api);
       },
     }),
     // Retrieves token and stores credentials and name in localStorage.
@@ -548,4 +549,15 @@ export function getCredentialsEntry(): CredentialsStorageEntry | null {
 export function clearLocalStorage() {
   console.info("clear localStorage");
   localStorage.clear();
+}
+
+// This is to make it easier to write async functions inside useEffect.
+export default function useEffectAsync(
+  effect: () => Promise<any>,
+  inputs: DependencyList
+) {
+  useEffect(() => {
+    // noinspection JSIgnoredPromiseFromCall
+    effect();
+  }, inputs);
 }

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -61,7 +61,7 @@ const AccountSettingsFormGroup: React.FC<{
       SignUpDate: user!.SignUpDate,
       GoogleID: user!.GoogleID,
     });
-    if ((response as any).error === undefined) {
+    if ("data" in response) {
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
     }

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -2,24 +2,27 @@ import React, { useEffect, useState } from "react";
 import { Container, Form } from "semantic-ui-react";
 import Buttons from "../../Atoms/Button/Buttons";
 import styles from "./accountformgroup.module.css";
-import {
+import useEffectAsync, {
   getUserIDFromToken,
   useGetTokenMutation,
   useUpdateUserMutation,
   useUserProtectedQuery,
 } from "../../../../api";
 import { UserType } from "../../../../api";
-import { useAppSelector } from "../../../../store";
 
 const AccountSettingsFormGroup: React.FC<{
   disabled: boolean;
   setDisabledForm: (value: boolean) => void;
 }> = ({ disabled, setDisabledForm }) => {
   const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
-  useEffect(() => {
-    getToken();
+  const [token, setToken] = useState(null as string | null);
+
+  useEffectAsync(async () => {
+    const response = await getToken();
+    if ("data" in response) {
+      setToken(response.data);
+    }
   }, []);
-  const token = useAppSelector((state) => state.token.token);
 
   let userID = "";
   if (tokenIsSuccess && token !== null) {

--- a/app/src/components/UI/Pages/EditVendorPage.tsx
+++ b/app/src/components/UI/Pages/EditVendorPage.tsx
@@ -118,7 +118,7 @@ const EditVendorPage: React.FC = () => {
       Owner: userID as string,
     };
     const response = await updateVendor(vendor);
-    if ((response as any).error === undefined) {
+    if ("data" in response) {
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
     }

--- a/app/src/components/UI/Pages/Login.tsx
+++ b/app/src/components/UI/Pages/Login.tsx
@@ -33,7 +33,7 @@ export default function Login(): React.ReactElement {
         "194003030221-uf763jqlstob3kof9c8du4j869lcd4f4.apps.googleusercontent.com",
       callback: async (data) => {
         const response = await signInWithGoogle(data.credential);
-        if ((response as any).error === undefined) {
+        if ("data" in response) {
           navigate("/");
         }
       },
@@ -57,7 +57,7 @@ export default function Login(): React.ReactElement {
       Password: values.Password,
     });
 
-    if ((response as any).error === undefined) {
+    if ("data" in response) {
       navigate("/");
     }
   };

--- a/app/src/components/UI/Pages/Signup.tsx
+++ b/app/src/components/UI/Pages/Signup.tsx
@@ -53,7 +53,7 @@ export default function Signup(): React.ReactElement {
   });
 
   const onSubmit = async (data: inputValues) => {
-    const result = await createUser({
+    const response = await createUser({
       ID: uuid(),
       Username: data.username,
       Photo: uuid(),
@@ -66,7 +66,7 @@ export default function Signup(): React.ReactElement {
       GoogleID: null,
     });
 
-    if ((result as any).error === undefined) {
+    if ("data" in response) {
       await setCredentials({
         Username: data.username,
         Password: data.password,
@@ -88,7 +88,7 @@ export default function Signup(): React.ReactElement {
         "194003030221-uf763jqlstob3kof9c8du4j869lcd4f4.apps.googleusercontent.com",
       callback: async (data) => {
         const response = await signInWithGoogle(data.credential);
-        if ((response as any).error === undefined) {
+        if ("data" in response) {
           if (userType === UserType.Customer) {
             navigate("/");
           }

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -13,7 +13,6 @@ import useEffectAsync, {
 } from "../../../api";
 import { v4 as uuid } from "uuid";
 import { useNavigate } from "react-router-dom";
-import { useAppSelector } from "../../../store";
 
 interface inputValues {
   name: string;

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -55,8 +55,8 @@ export default function VendorAppForm(): React.ReactElement {
       Longitude: 0,
       Owner: userID,
     };
-    const result = await createVendor(vendor);
-    if ((result as any).error === undefined) {
+    const response = await createVendor(vendor);
+    if ("data" in response) {
       navigate("/vendor-dashboard");
     }
   };

--- a/app/src/components/UI/Pages/VendorAppForm.tsx
+++ b/app/src/components/UI/Pages/VendorAppForm.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Form, Container } from "semantic-ui-react";
 import Buttons from "../Atoms/Button/Buttons";
 import { Dropdown } from "semantic-ui-react";
 import styles from "./vendorappform.module.css";
 import { Formik, FormikProps, ErrorMessage, Field } from "formik";
 import * as Yup from "yup";
-import {
+import useEffectAsync, {
   getUserIDFromToken,
   useCreateVendorMutation,
   useGetTokenMutation,
@@ -29,20 +29,20 @@ export default function VendorAppForm(): React.ReactElement {
   const navigate = useNavigate();
   const [createVendor] = useCreateVendorMutation();
   const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
-  useEffect(() => {
-    getToken();
+  const [token, setToken] = useState(null as string | null);
+
+  useEffectAsync(async () => {
+    const response = await getToken();
+    if ("data" in response) {
+      setToken(response.data);
+    }
   }, []);
-  const token = useAppSelector((state) => state.token.token);
 
   if (!tokenIsSuccess || token === null) {
     return <p>Not logged in</p>;
   }
 
   const onSubmit = async (data: inputValues) => {
-    if (!tokenIsSuccess || token === null) {
-      // Button is inaccessible when token is null
-      throw new Error("unexpected");
-    }
     const userID = getUserIDFromToken(token);
     const vendor: Vendor = {
       ID: uuid(),


### PR DESCRIPTION
Before, the token was retrieved from store after calling `getToken`. This PR makes it more straightforward to use by returning the token directly from `getToken`.