### PR TITLE
VendorByOwnerID() - Return a single vendor

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -253,8 +253,8 @@ export const apiSlice = createApi({
         return { data: vendors };
       },
     }),
-    // Returns vendors with given owner ID. There should only be zero or one vendor associated with a user.
-    vendorByOwnerID: builder.query<Vendor[], string>({
+    // Returns vendors with given owner ID.
+    vendorByOwnerID: builder.query<Vendor, string>({
       query: (ownerID) => `/vendors?owner=${encode(ownerID)}`,
     }),
     createVendor: builder.mutation<undefined, Vendor>({

--- a/app/src/components/UI/Pages/EditVendorPage.tsx
+++ b/app/src/components/UI/Pages/EditVendorPage.tsx
@@ -58,7 +58,7 @@ const EditVendorPage: React.FC = () => {
   }
 
   const {
-    data: vendors,
+    data: vendor,
     isSuccess: vendorQueryIsSuccess,
     isLoading: vendorQueryIsLoading,
   } = useVendorByOwnerIDQuery(userID as string, { skip: !userID });
@@ -74,25 +74,20 @@ const EditVendorPage: React.FC = () => {
   const [showSuccess, setShowSuccess] = useState(false);
 
   useEffect(() => {
-    if (vendorQueryIsSuccess && vendors!.length > 0) {
-      const vendor = vendors![0];
+    if (vendorQueryIsSuccess) {
       setInitalValues({
-        ID: vendor.ID,
-        name: vendor.Name,
-        businessAddress: vendor.BusinessAddress,
-        phoneNumber: vendor.Phone,
-        businessHours: vendor.BusinessHours,
-        website: vendor.Website,
+        ID: vendor!.ID,
+        name: vendor!.Name,
+        businessAddress: vendor!.BusinessAddress,
+        phoneNumber: vendor!.Phone,
+        businessHours: vendor!.BusinessHours,
+        website: vendor!.Website,
       });
     }
   }, [vendorQueryIsSuccess]);
 
   if (tokenIsSuccess && !token) {
     return <p>Not logged in</p>;
-  }
-
-  if (vendorQueryIsSuccess && vendors!.length === 0) {
-    return <p>No vendor found with matching owner ID</p>;
   }
 
   const validationSchema = Yup.object({

--- a/backend/api.go
+++ b/backend/api.go
@@ -191,13 +191,13 @@ func (a *API) Vendors(c *gin.Context) {
 			return
 		}
 
-		vendors, err := a.Backend.VendorByOwnerID(ownerID)
+		vendor, err := a.Backend.VendorByOwnerID(ownerID)
 		if err != nil {
 			c.Error(err)
 			return
 		}
 
-		c.JSON(http.StatusOK, vendors)
+		c.JSON(http.StatusOK, vendor)
 		return
 	}
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/bcfoodapp/streetfoodlove/database"
@@ -49,13 +50,14 @@ func (b *Backend) VendorCreate(userID uuid.UUID, vendor *database.Vendor) error 
 		return fmt.Errorf("owner field does not match userID")
 	}
 
-	existingVendors, err := b.Database.VendorByOwnerID(userID)
-	if err != nil {
-		return err
-	}
-
-	if len(existingVendors) > 0 {
-		return fmt.Errorf("you already have a vendor; each user may only be associated with up to one vendor")
+	_, err = b.Database.VendorByOwnerID(userID)
+	// Check that vendor for owner does not exist. It should return sql.ErrNoRows if there is no owner.
+	if err != sql.ErrNoRows {
+		if err != nil {
+			return err
+		} else {
+			return fmt.Errorf("you already have a vendor; each user may only be associated with up to one vendor")
+		}
 	}
 
 	return b.Database.VendorCreate(vendor)
@@ -69,7 +71,7 @@ func (b *Backend) VendorUpdate(userID uuid.UUID, vendor *database.Vendor) error 
 	return b.Database.VendorUpdate(vendor)
 }
 
-func (b *Backend) VendorByOwnerID(userID uuid.UUID) ([]database.Vendor, error) {
+func (b *Backend) VendorByOwnerID(userID uuid.UUID) (*database.Vendor, error) {
 	return b.Database.VendorByOwnerID(userID)
 }
 

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -93,10 +93,9 @@ func (d *Database) Vendor(id uuid.UUID) (*Vendor, error) {
 	const command = `
 		SELECT * FROM Vendor WHERE ID=?;
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	vendor := &Vendor{}
-	err := row.StructScan(vendor)
+	err := d.db.QueryRowx(command, &id).StructScan(vendor)
 	return vendor, err
 }
 
@@ -152,29 +151,16 @@ func (d *Database) VendorsByCoordinateBounds(bounds *CoordinateBounds) ([]Vendor
 	return result, rows.Err()
 }
 
-func (d *Database) VendorByOwnerID(userID uuid.UUID) ([]Vendor, error) {
+func (d *Database) VendorByOwnerID(userID uuid.UUID) (*Vendor, error) {
 	const command = `
 		SELECT *
 		FROM Vendor
 		WHERE Owner = ?
 	`
 
-	rows, err := d.db.Queryx(command, &userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	result := make([]Vendor, 0)
-
-	for rows.Next() {
-		result = append(result, Vendor{})
-		if err := rows.StructScan(&result[len(result)-1]); err != nil {
-			return nil, err
-		}
-	}
-
-	return result, rows.Err()
+	vendor := &Vendor{}
+	err := d.db.QueryRowx(command, &userID).StructScan(vendor)
+	return vendor, err
 }
 
 type UserType int
@@ -255,10 +241,9 @@ func (d *Database) User(id uuid.UUID) (*UserProtected, error) {
 		FROM User
 		WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	user := &UserProtected{}
-	err := row.StructScan(user)
+	err := d.db.QueryRowx(command, &id).StructScan(user)
 	return user, err
 }
 
@@ -289,11 +274,10 @@ func (d *Database) UserIDByCredentials(credentials *Credentials) (uuid.UUID, err
 		FROM User
 		WHERE Username=?
 	`
-	row := d.db.QueryRowx(command, &credentials.Username)
 
 	userID := uuid.UUID{}
 	var passwordHash []byte
-	err := row.Scan(&userID, &passwordHash)
+	err := d.db.QueryRowx(command, &credentials.Username).Scan(&userID, &passwordHash)
 	if err != nil {
 		return [16]byte{}, err
 	}
@@ -314,10 +298,8 @@ func (d *Database) UserIDByGoogleID(googleID string) (uuid.UUID, error) {
 		WHERE GoogleID=?
 	`
 
-	row := d.db.QueryRowx(command, &googleID)
-
 	userID := uuid.UUID{}
-	err := row.Scan(&userID)
+	err := d.db.QueryRowx(command, &googleID).Scan(&userID)
 	return userID, err
 }
 
@@ -362,10 +344,9 @@ func (d *Database) Review(id uuid.UUID) (*Review, error) {
 	const command = `
 		SELECT * FROM Reviews WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	review := &Review{}
-	err := row.StructScan(review)
+	err := d.db.QueryRowx(command, &id).StructScan(review)
 	return review, err
 }
 
@@ -423,10 +404,9 @@ func (d *Database) Photo(id uuid.UUID) (*Photo, error) {
 	const command = `
 		SELECT * FROM Photos WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	photo := &Photo{}
-	err := row.StructScan(photo)
+	err := d.db.QueryRowx(command, &id).StructScan(photo)
 
 	return photo, err
 }
@@ -483,10 +463,9 @@ func (d *Database) Guide(id uuid.UUID) (*Guide, error) {
 	const command = `
 		SELECT * FROM Guide WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	guide := &Guide{}
-	err := row.StructScan(guide)
+	err := d.db.QueryRowx(command, &id).StructScan(guide)
 
 	return guide, err
 }
@@ -517,10 +496,9 @@ func (d *Database) Link(id uuid.UUID) (*Link, error) {
 	const command = `
 		SELECT * FROM Link WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	link := &Link{}
-	err := row.StructScan(link)
+	err := d.db.QueryRowx(command, &id).StructScan(link)
 
 	return link, err
 
@@ -556,9 +534,8 @@ func (d *Database) Favorite(id uuid.UUID) (*Favorite, error) {
 	const command = `
 		SELECT * FROM Favorite WHERE ID=?
 	`
-	row := d.db.QueryRowx(command, &id)
 
 	favorite := &Favorite{}
-	err := row.StructScan(favorite)
+	err := d.db.QueryRowx(command, &id).StructScan(favorite)
 	return favorite, err
 }


### PR DESCRIPTION
This is to improve usability of the API. As one user should be associated with 0 or 1 vendors, `VendorByOwnerID()` is changed so that it returns a single vendor on success instead of an array of vendors.