### PR TITLE
Fix click issue with drag-and-drop component

### DIFF
--- a/app/src/components/UI/Organisms/DragAndDrop/DragAndDrop.tsx
+++ b/app/src/components/UI/Organisms/DragAndDrop/DragAndDrop.tsx
@@ -5,8 +5,8 @@ import styles from "./draganddrop.module.css";
 
 interface Props {
   onDrop: Exclude<DropzoneProps["onDropAccepted"], undefined>;
-  // true to allow multiple file selections. true is default.
-  multiple?: boolean;
+  // true to allow multiple file selections.
+  multiple: boolean;
 }
 
 export default ({ onDrop, multiple }: Props): React.ReactElement => {
@@ -22,7 +22,7 @@ export default ({ onDrop, multiple }: Props): React.ReactElement => {
         onDropRejected={() => setShowUploadError(true)}
         maxSize={1_000_000}
         multiple={multiple}
-        noClick
+        noClick={!multiple}
       >
         {({ getRootProps, getInputProps, isDragAccept }) => {
           let dragAndDropStyles = styles.dragAndDrop;

--- a/app/src/components/UI/Organisms/ReviewForm/ReviewForm.tsx
+++ b/app/src/components/UI/Organisms/ReviewForm/ReviewForm.tsx
@@ -60,6 +60,7 @@ export const ReviewForm = (props: Props) => {
           onDrop={(files: File[]) => {
             setFiles((state) => [...state, ...files]);
           }}
+          multiple
         />
         {files.map((file, i) => (
           <p key={i}>{file.name}</p>

--- a/app/src/components/UI/Pages/VendorPhotosUploader.tsx
+++ b/app/src/components/UI/Pages/VendorPhotosUploader.tsx
@@ -103,7 +103,7 @@ export default (): React.ReactElement => {
       {s3CredentialsIsLoading ? (
         <p>Getting AWS credentials</p>
       ) : vendor ? (
-        <DragAndDrop onDrop={onDrop} />
+        <DragAndDrop onDrop={onDrop} multiple />
       ) : (
         <p>Vendor loading</p>
       )}


### PR DESCRIPTION
This fixes the issue which clicking on a drag-and-drop did not open the dialog. It looks like only those with the multiple attribute did not open the dialog. Their `noClick` attributes are set to false, and others are set to true to ensure their behaviors are correct as well.