### PR TITLE
Fix backspace in search box

### DIFF
--- a/app/src/components/UI/Atoms/SearchBox/SearchBox.tsx
+++ b/app/src/components/UI/Atoms/SearchBox/SearchBox.tsx
@@ -21,9 +21,13 @@ export const SearchBox: React.FC = () => {
 
     let array: Vendor[] = [];
 
-    if (vendorsList !== undefined) {
+    if (vendorsList) {
       for (const vendor of vendorsList) {
-        if (vendor.Name === searchString && resultSet.has(vendor.Name)) {
+        if (
+          vendor.Name === searchString &&
+          resultSet.has(vendor.Name) &&
+          !recentSearchResult.some((item) => item.Name === searchString)
+        ) {
           let obj = {
             title: vendor.Name,
             description: vendor.BusinessAddress,

--- a/app/src/components/UI/Atoms/SearchBox/SearchBox.tsx
+++ b/app/src/components/UI/Atoms/SearchBox/SearchBox.tsx
@@ -48,7 +48,7 @@ export const SearchBox: React.FC = () => {
     let string = "";
     if (data.value) {
       string = data.value;
-    } else {
+    } else if (data.result && data.result.title) {
       string = data.result.title;
     }
     setSearchString(string);


### PR DESCRIPTION
The issue regarding pressing backspace in the search box is fixed by ensuring the property exists in `data`.