### PR TITLE
ChangeOpenSearch query type

### DIFF
--- a/app/src/search.ts
+++ b/app/src/search.ts
@@ -8,8 +8,8 @@ export async function search(searchString: string) {
     "source",
     JSON.stringify({
       query: {
-        wildcard: {
-          Name: `*${searchString}*`,
+        match: {
+          Name: searchString,
         },
       },
     })


### PR DESCRIPTION
Because all vendors now have distinct names, the `match` query works better than `wildcard` to query by words.