### PR TITLE
Add layout for New Reviews page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import HeaderBar from "./components/UI/Molecules/HeaderBar/HeaderBar";
 import MessageError from "./components/UI/Atoms/Message/MessageError";
 import LoginWrapper from "./components/UI/Pages/Login";
 import VendorPhotosUploader from "./components/UI/Pages/VendorPhotosUploader";
+import NewReviews from "./components/UI/Pages/NewReviews/NewReviews";
 
 function App(): React.ReactElement {
   return (
@@ -38,6 +39,10 @@ function App(): React.ReactElement {
           <Route
             path="/vendor-dashboard/photos"
             element={<VendorPhotosUploader />}
+          />
+          <Route
+            path="/vendor-dashboard/new-reviews"
+            element={<NewReviews />}
           />
           <Route path="/edit-vendor-page" element={<EditVendorPage />} />
           <Route path="/guides/:ID" element={<BusinessGuideArticle />} />

--- a/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
+++ b/app/src/components/UI/Molecules/Form Group/AccountSettingsFormGroup.tsx
@@ -21,24 +21,20 @@ const AccountSettingsFormGroup: React.FC<{
   setDisabledForm: (value: boolean) => void;
 }> = ({ disabled, setDisabledForm }) => {
   const [getToken] = useGetTokenMutation();
-  const [token, setToken] = useState(null as string | null);
+  const [userID, setUserID] = useState(null as string | null);
 
   useEffectAsync(async () => {
     const response = await getToken();
-    if ("data" in response) {
-      setToken(response.data);
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
     }
   }, []);
 
-  let userID = "";
-  if (token) {
-    userID = getUserIDFromToken(token as string);
-  }
   const {
     data: user,
     isSuccess: userQueryIsSuccess,
     isLoading: userQueryIsLoading,
-  } = useUserProtectedQuery(userID, { skip: userID === "" });
+  } = useUserProtectedQuery(userID!, { skip: userID === null });
 
   const [updateUser] = useUpdateUserMutation();
   const [email, setEmail] = useState("");
@@ -89,7 +85,7 @@ const AccountSettingsFormGroup: React.FC<{
     setIsSubmitting(false);
   };
 
-  if (token === null) {
+  if (userID === null) {
     return <p>Not logged in</p>;
   }
 

--- a/app/src/components/UI/Organisms/AccountProfileStars/AccountProfileStars.tsx
+++ b/app/src/components/UI/Organisms/AccountProfileStars/AccountProfileStars.tsx
@@ -18,25 +18,20 @@ function VendorName({ vendorID }: VendorNameProps): React.ReactElement {
 
 export default (): React.ReactElement => {
   const [getToken] = useGetTokenMutation();
-  const [token, setToken] = useState(null as string | null);
+  const [userID, setUserID] = useState(null as string | null);
 
   useEffectAsync(async () => {
     const response = await getToken();
-    if ("data" in response) {
-      setToken(response.data);
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
     }
   }, []);
 
-  let userID = "";
-  if (token) {
-    userID = getUserIDFromToken(token as string);
-  }
-
-  const { data: stars } = useStarsByUserIDQuery(userID, {
-    skip: userID === "",
+  const { data: stars } = useStarsByUserIDQuery(userID!, {
+    skip: !userID,
   });
 
-  if (!token) {
+  if (userID === null) {
     return <p>Not logged in</p>;
   }
 

--- a/app/src/components/UI/Organisms/Review/Review.tsx
+++ b/app/src/components/UI/Organisms/Review/Review.tsx
@@ -39,14 +39,11 @@ interface Props {
 export const Review: React.FC<Props> = ({ review, reviewID, vendorID }) => {
   const [openCommentForm, setOpenCommentForm] = useState(false);
   const [CommentInput, setCommentInput] = useState("");
-  // const [vendorLiked, setVendorLiked] = useState(false);
   const [submitReview] = useCreateReviewMutation();
   const [submitUpdatedReview] = useUpdateReviewMutation();
   const token = useAppSelector((state) => state.token.token);
   const { data: user } = useUserQuery(review.UserID);
   const { data: photos } = usePhotosByLinkIDQuery(review.ID);
-
-  console.log(review);
 
   useEffect(() => {
     styleComments();

--- a/app/src/components/UI/Pages/EditVendorPage.tsx
+++ b/app/src/components/UI/Pages/EditVendorPage.tsx
@@ -47,27 +47,22 @@ const EditVendorPage: React.FC = () => {
   const [updateVendor] = useUpdateVendorMutation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
-  const [token, setToken] = useState(null as string | null);
+  const [userID, setUserID] = useState(null as string | null);
   const [logoFile, setLogoFile] = useState(null as File | null);
   const [coordinatesChanged, setCoordinatesChanged] = useState(false);
 
   useEffectAsync(async () => {
     const response = await getToken();
-    if ("data" in response) {
-      setToken(response.data);
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
     }
   }, []);
-
-  let userID = null as string | null;
-  if (token) {
-    userID = getUserIDFromToken(token);
-  }
 
   const {
     data: vendor,
     isSuccess: vendorQueryIsSuccess,
     isLoading: vendorQueryIsLoading,
-  } = useVendorByOwnerIDQuery(userID as string, { skip: !userID });
+  } = useVendorByOwnerIDQuery(userID!, { skip: !userID });
 
   const [initialValues, setInitalValues] = useState({
     name: "",
@@ -98,7 +93,7 @@ const EditVendorPage: React.FC = () => {
 
   const [getS3Credentials] = useS3CredentialsMutation();
 
-  if (tokenIsSuccess && !token) {
+  if (userID === null) {
     return <p>Not logged in</p>;
   }
 

--- a/app/src/components/UI/Pages/NewReviews/NewReviews.tsx
+++ b/app/src/components/UI/Pages/NewReviews/NewReviews.tsx
@@ -20,13 +20,14 @@ export default (): React.ReactElement => {
     }
   }, []);
 
-  const { data: vendor } = useVendorByOwnerIDQuery(userID as string, {
+  const { data: vendor } = useVendorByOwnerIDQuery(userID!, {
     skip: !userID,
   });
 
   const review = {
     Text: "Text",
     StarRating: 5,
+    VendorID: vendor?.ID,
   } as ReviewObj;
 
   if (userID === null) {

--- a/app/src/components/UI/Pages/NewReviews/NewReviews.tsx
+++ b/app/src/components/UI/Pages/NewReviews/NewReviews.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { Container } from "semantic-ui-react";
+import {
+  getUserIDFromToken,
+  useEffectAsync,
+  useGetTokenMutation,
+  useVendorByOwnerIDQuery,
+  Review as ReviewObj,
+} from "../../../../api";
+import { Review } from "../../Organisms/Review/Review";
+
+export default (): React.ReactElement => {
+  const [getToken] = useGetTokenMutation();
+  const [userID, setUserID] = useState(null as string | null);
+
+  useEffectAsync(async () => {
+    const response = await getToken();
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
+    }
+  }, []);
+
+  const { data: vendor } = useVendorByOwnerIDQuery(userID as string, {
+    skip: !userID,
+  });
+
+  const review = {
+    Text: "Text",
+    StarRating: 5,
+  } as ReviewObj;
+
+  if (userID === null) {
+    return <p>Not logged in</p>;
+  }
+
+  return (
+    <Container>
+      <h1>New Reviews for {vendor?.Name}</h1>
+      {vendor ? (
+        <Review review={review} reviewID={""} vendorID={vendor.ID} />
+      ) : null}
+    </Container>
+  );
+};

--- a/app/src/components/UI/Pages/VendorDashboard.tsx
+++ b/app/src/components/UI/Pages/VendorDashboard.tsx
@@ -12,25 +12,24 @@ import { s3Prefix } from "../../../aws";
 
 const VendorDashBoard: React.FC = () => {
   const [getToken] = useGetTokenMutation();
-  const [token, setToken] = useState(null as string | null);
+  const [userID, setUserID] = useState(null as string | null);
 
   useEffectAsync(async () => {
     const response = await getToken();
-    if ("data" in response) {
-      setToken(response.data);
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
     }
   }, []);
-
-  let userID = null as string | null;
-  if (token) {
-    userID = getUserIDFromToken(token);
-  }
 
   const { data: vendor } = useVendorByOwnerIDQuery(userID as string, {
     skip: !userID,
   });
 
   const navigate = useNavigate();
+
+  if (userID === null) {
+    return <p>Not logged in</p>;
+  }
 
   return (
     <Container className={styles.wrapper}>
@@ -96,7 +95,7 @@ const VendorDashBoard: React.FC = () => {
             </Card.Content>
           </Card>
         </Link>
-        <Link to="">
+        <Link to="/vendor-dashboard/new-reviews">
           <Card className={styles.card}>
             <Icon name="write" size="huge" className={styles.icon} />
             <Card.Content className={styles.content}>

--- a/app/src/components/UI/Pages/VendorPhotosUploader.tsx
+++ b/app/src/components/UI/Pages/VendorPhotosUploader.tsx
@@ -33,13 +33,10 @@ export default (): React.ReactElement => {
   let userID = null as string | null;
   if (token) {
     userID = getUserIDFromToken(token);
-    // console.log('userID: ' + userID);
   }
 
   const { data: vendor, isLoading: vendorQueryIsLoading } =
     useVendorByOwnerIDQuery(userID as string, { skip: !userID });
-
-  console.log("vendor: " + JSON.stringify(vendor));
 
   const { data: photos, isLoading: photosIsLoading } = usePhotosByLinkIDQuery(
     vendor ? vendor.ID : "",

--- a/app/src/components/UI/Pages/VendorPhotosUploader.tsx
+++ b/app/src/components/UI/Pages/VendorPhotosUploader.tsx
@@ -21,22 +21,17 @@ import DragAndDrop from "../Organisms/DragAndDrop/DragAndDrop";
 export default (): React.ReactElement => {
   const [uploading, setUploading] = useState(false);
   const [getToken, { isSuccess: tokenIsSuccess }] = useGetTokenMutation();
-  const [token, setToken] = useState(null as string | null);
+  const [userID, setUserID] = useState(null as string | null);
 
   useEffectAsync(async () => {
     const response = await getToken();
-    if ("data" in response) {
-      setToken(response.data);
+    if ("data" in response && response.data) {
+      setUserID(getUserIDFromToken(response.data));
     }
   }, []);
 
-  let userID = null as string | null;
-  if (token) {
-    userID = getUserIDFromToken(token);
-  }
-
   const { data: vendor, isLoading: vendorQueryIsLoading } =
-    useVendorByOwnerIDQuery(userID as string, { skip: !userID });
+    useVendorByOwnerIDQuery(userID!, { skip: !userID });
 
   const { data: photos, isLoading: photosIsLoading } = usePhotosByLinkIDQuery(
     vendor ? vendor.ID : "",
@@ -77,7 +72,7 @@ export default (): React.ReactElement => {
     }
   };
 
-  if (!tokenIsSuccess || token === null) {
+  if (userID === null) {
     return <p>Not logged in</p>;
   }
 


### PR DESCRIPTION
This adds a skeleton for the New Reviews page at `/vendor-dashboard/new-reviews`. It does return API errors because I am using a sample review and its IDs are invalid. But with actual review data, the IDs will be correct.

The code to get the user ID is simplified.