### PR TITLE
Add API for new review notification

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -346,7 +346,6 @@ func (a *API) Reviews(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, reviews)
-	return
 }
 
 func (a *API) Review(c *gin.Context) {

--- a/backend/api.go
+++ b/backend/api.go
@@ -323,13 +323,30 @@ func (a *API) Reviews(c *gin.Context) {
 		return
 	}
 
-	reviews, err := a.Backend.ReviewsByVendorID(vendorID)
-	if err != nil {
-		c.Error(err)
-		return
+	var reviews []database.Review
+
+	if c.Query("afterReview") == "" {
+		reviews, err = a.Backend.ReviewsByVendorID(vendorID)
+		if err != nil {
+			c.Error(err)
+			return
+		}
+	} else {
+		afterReviewID, err := uuid.Parse(c.Query("afterReview"))
+		if err != nil {
+			c.Error(err)
+			return
+		}
+
+		reviews, err = a.Backend.ReviewsPostedAfterReview(vendorID, afterReviewID)
+		if err != nil {
+			c.Error(err)
+			return
+		}
 	}
 
 	c.JSON(http.StatusOK, reviews)
+	return
 }
 
 func (a *API) Review(c *gin.Context) {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -147,6 +147,30 @@ func (b *Backend) ReviewsByVendorID(vendorID uuid.UUID) ([]database.Review, erro
 	return b.Database.ReviewsByVendorID(vendorID)
 }
 
+func (b *Backend) ReviewsPostedAfterReview(vendorID uuid.UUID, afterReview uuid.UUID) ([]database.Review, error) {
+	lastSeenReview, err := b.Database.Review(afterReview)
+	if err != nil {
+		return nil, err
+	}
+
+	vendorReviews, err := b.Database.ReviewsByVendorID(vendorID)
+	if err != nil {
+		return nil, err
+	}
+
+	return selectReviewsAfterTime(vendorReviews, lastSeenReview.DatePosted), nil
+}
+
+func selectReviewsAfterTime(reviews []database.Review, afterTime time.Time) []database.Review {
+	var result []database.Review
+	for _, review := range reviews {
+		if review.DatePosted.After(afterTime) {
+			result = append(result, review)
+		}
+	}
+	return result
+}
+
 func (b *Backend) VendorsByCoordinateBounds(bounds *database.CoordinateBounds) ([]uuid.UUID, error) {
 	vendors, err := b.Database.VendorsByCoordinateBounds(bounds)
 	if err != nil {

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/bcfoodapp/streetfoodlove/database"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSelectReviewsAftertime(t *testing.T) {
+	tests := []struct {
+		reviews   []database.Review
+		afterTime time.Time
+		expected  []database.Review
+	}{
+		{
+			nil,
+			time.Date(0, 0, 0, 0, 0, 1, 0, time.UTC),
+			nil,
+		},
+		{
+			[]database.Review{
+				{
+					DatePosted: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			time.Date(0, 0, 0, 0, 0, 1, 0, time.UTC),
+			nil,
+		},
+		{
+			[]database.Review{
+				{
+					DatePosted: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					DatePosted: time.Date(0, 0, 0, 0, 0, 2, 0, time.UTC),
+				},
+			},
+			time.Date(0, 0, 0, 0, 0, 1, 0, time.UTC),
+			[]database.Review{
+				{
+					DatePosted: time.Date(0, 0, 0, 0, 0, 2, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		assert.Equal(t, test.expected, selectReviewsAfterTime(test.reviews, test.afterTime), i)
+	}
+}

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -186,9 +186,10 @@ type User struct {
 // UserProtected contains User fields plus fields that are password-protected.
 type UserProtected struct {
 	*User
-	Email      string
-	SignUpDate time.Time
-	GoogleID   *string
+	Email          string
+	SignUpDate     time.Time
+	GoogleID       *string
+	LastReviewSeen uuid.UUID
 }
 
 func (d *Database) UserCreate(user *UserProtected, password string) error {
@@ -239,7 +240,8 @@ func (d *Database) User(id uuid.UUID) (*UserProtected, error) {
 			SignUpDate,
 			UserType,
 			Photo,
-			GoogleID
+			GoogleID,
+			LastReviewSeen
 		FROM User
 		WHERE ID=?
 	`
@@ -258,7 +260,8 @@ func (d *Database) UserUpdate(user *UserProtected) error {
 			LastName = :LastName,
 			UserType = :UserType,
 			Photo = :Photo,
-			GoogleID = :GoogleID
+			GoogleID = :GoogleID,
+			LastReviewSeen = :LastReviewSeen
 		WHERE ID = :ID
 	`
 	_, err := d.db.NamedExec(command, &user)

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -168,9 +168,7 @@ func (d *Database) VendorByOwnerID(userID uuid.UUID) (*Vendor, error) {
 type UserType int
 
 const (
-	// nolint: deadcode
 	UserTypeCustomer UserType = iota
-	// nolint: deadcode
 	UserTypeVendor
 )
 

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -187,7 +187,7 @@ type UserProtected struct {
 	Email          string
 	SignUpDate     time.Time
 	GoogleID       *string
-	LastReviewSeen uuid.UUID
+	LastReviewSeen *uuid.UUID
 }
 
 func (d *Database) UserCreate(user *UserProtected, password string) error {

--- a/backend/reset_database/main.go
+++ b/backend/reset_database/main.go
@@ -77,6 +77,7 @@ func SetupTables(db *sqlx.DB) error {
 			UserType TINYINT NULL,
 			Photo VARCHAR(50) NOT NULL,
 			GoogleID VARCHAR(50) UNIQUE NULL,
+			LastReviewSeen CHAR(36) NULL,
 			PRIMARY KEY (ID)
 		)
 		`,
@@ -177,6 +178,11 @@ func SetupTables(db *sqlx.DB) error {
 			PRIMARY KEY (VendorID, CuisineType),
 			FOREIGN KEY (VendorID) REFERENCES Vendor(ID) ON DELETE CASCADE ON UPDATE CASCADE
 		)
+		`,
+		`
+		ALTER TABLE User
+			ADD FOREIGN KEY (LastReviewSeen) REFERENCES Reviews(ID)
+			ON DELETE SET NULL ON UPDATE CASCADE
 		`,
 	}
 


### PR DESCRIPTION
This adds the `afterReview` parameter to `GET /reviews/` which filters results by any review that came after the passed review.