### PR TITLE
Fix QR code URL

### DIFF
--- a/app/src/components/UI/Molecules/HeaderBar/HeaderBar.tsx
+++ b/app/src/components/UI/Molecules/HeaderBar/HeaderBar.tsx
@@ -57,7 +57,7 @@ export default function HeaderBar(): React.ReactElement {
         <Menu.Item>
           <h2 className={styles.title}>
             <Image
-              src="/logo.svg"
+              src="/streetfoodlove/logo.svg"
               alt="StreetFoodLove logo"
               style={{ width: 200 }}
             />

--- a/app/src/components/UI/Pages/DiscountQRCode/DiscountQRCode.tsx
+++ b/app/src/components/UI/Pages/DiscountQRCode/DiscountQRCode.tsx
@@ -3,7 +3,6 @@ import QRCode from "react-qr-code";
 import { Link, useParams } from "react-router-dom";
 import { useDiscountQuery } from "../../../../api";
 import { Container, Header } from "semantic-ui-react";
-import config from "../../../../configuration.json";
 
 export default (): React.ReactElement => {
   const id = useParams().ID as string;
@@ -19,7 +18,9 @@ export default (): React.ReactElement => {
       {discountURL ? (
         <>
           <Container textAlign="center">
-            <QRCode value={config.apiBaseURL + discountURL} />
+            <QRCode
+              value={`${window.location.origin}/streetfoodlove${discountURL}`}
+            />
           </Container>
 
           <p>URL for testing:</p>


### PR DESCRIPTION
The QR code URL is fixed so that it has the frontend host, not the API host.

This also fixes the image path for the StreetFoodLove logo.