### PR TITLE
Add guide info to front page

### DIFF
--- a/app/src/__tests__/tests.ts
+++ b/app/src/__tests__/tests.ts
@@ -1,4 +1,5 @@
 import { getExtension } from "../api";
+import { firstWords } from "../components/UI/Pages/BusinessGuides";
 
 test("getExtension", () => {
   expect(getExtension("")).toBe("");
@@ -7,4 +8,18 @@ test("getExtension", () => {
   expect(getExtension("a.b")).toBe("b");
   expect(getExtension("a.b.")).toBe("");
   expect(getExtension("a.b.c")).toBe("c");
+});
+
+test("firstWords", () => {
+  expect(firstWords("", 0)).toBe("");
+  expect(firstWords("", 1)).toBe("");
+  expect(firstWords(" ", 0)).toBe("");
+  expect(firstWords(" ", 1)).toBe("");
+  expect(firstWords("  ", 1)).toBe("");
+  expect(firstWords("  ", 2)).toBe(" ");
+  expect(firstWords("a b", 0)).toBe("");
+  expect(firstWords("a b", 1)).toBe("a");
+  expect(firstWords("a b", 2)).toBe("a b");
+  expect(firstWords("a b", 3)).toBe("a b");
+  expect(firstWords("a b ", 2)).toBe("a b");
 });

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -475,6 +475,16 @@ export const apiSlice = createApi({
         url: `/map/view/${rectangle.northWestLat}/${rectangle.northWestLng}/${rectangle.southEastLat}/${rectangle.southEastLng}`,
       }),
     }),
+    guides: builder.query<Guide[], void>({
+      query: () => ({
+        url: `/guides`,
+      }),
+      transformResponse: (guides: any[]) =>
+        guides.map((guide) => ({
+          ...guide,
+          DatePosted: DateTime.fromISO(guide.DatePosted),
+        })),
+    }),
     guide: builder.query<Guide, string>({
       query: (id) => ({
         url: `/guides/${id}`,
@@ -843,6 +853,7 @@ export const {
   useGetTokenMutation,
   useSetCredentialsAndGetTokenMutation,
   useMapViewVendorsQuery,
+  useGuidesQuery,
   useGuideQuery,
   useSignInWithGoogleMutation,
   usePhotosByLinkIDQuery,

--- a/app/src/components/UI/Pages/BusinessGuides.tsx
+++ b/app/src/components/UI/Pages/BusinessGuides.tsx
@@ -2,6 +2,21 @@ import { Container, Header, Card } from "semantic-ui-react";
 import styles from "./businessGuide.module.css";
 import { useGuidesQuery } from "../../../api";
 
+// Returns the first n words of string.
+export function firstWords(s: string, numberOfSpaces: number): string {
+  let currentIndex = 0;
+  for (let i = 0; i < numberOfSpaces; i++) {
+    const index = s.indexOf(" ", currentIndex);
+    if (index === -1) {
+      currentIndex = s.length + 1;
+      break;
+    }
+    currentIndex = index + 1;
+  }
+
+  return s.substring(0, currentIndex - 1);
+}
+
 const BusinessGuides: React.FC = () => {
   const { data: guides } = useGuidesQuery();
 
@@ -17,7 +32,7 @@ const BusinessGuides: React.FC = () => {
             {guides?.slice(0, 4).map((guide, i) => (
               <Card
                 header={`Guide ${i}`}
-                description={`${guide.Guide.substring(0, 50)}...`}
+                description={`${firstWords(guide.Guide, 15)}...`}
               />
             ))}
           </Card.Group>
@@ -25,10 +40,10 @@ const BusinessGuides: React.FC = () => {
         <Container className={styles.newCards}>
           <Header as="h2">Recently Posted</Header>
           <Card.Group itemsPerRow={2}>
-            {guides?.slice(0, 4).map((guide, i) => (
+            {guides?.map((guide, i) => (
               <Card
                 header={`Guide ${i}`}
-                description={`${guide.Guide.substring(0, 50)}...`}
+                description={`${firstWords(guide.Guide, 15)}...`}
               />
             ))}
           </Card.Group>

--- a/app/src/components/UI/Pages/BusinessGuides.tsx
+++ b/app/src/components/UI/Pages/BusinessGuides.tsx
@@ -1,7 +1,10 @@
 import { Container, Header, Card } from "semantic-ui-react";
 import styles from "./businessGuide.module.css";
+import { useGuidesQuery } from "../../../api";
 
 const BusinessGuides: React.FC = () => {
+  const { data: guides } = useGuidesQuery();
+
   return (
     <Container className={styles.wrapper}>
       <Header as="h2" className={styles.title}>
@@ -9,51 +12,25 @@ const BusinessGuides: React.FC = () => {
       </Header>
       <Container className={styles.content}>
         <Container>
-          <Header as="h2">Popular!</Header>
+          <Header as="h2">Popular</Header>
           <Card.Group itemsPerRow={2}>
-            <Card
-              href="#"
-              header="Business Guide 1"
-              meta="Beginner"
-              description="Business guide one description."
-            />
-            <Card
-              href="#"
-              header="Business Guide 2"
-              meta="Beginner"
-              description="Business guide one description."
-            />
-
-            <Card
-              href="#"
-              header="Business Guide 3"
-              meta="Intermediate"
-              description="Business guide one description."
-            />
+            {guides?.slice(0, 4).map((guide, i) => (
+              <Card
+                header={`Guide ${i}`}
+                description={`${guide.Guide.substring(0, 50)}...`}
+              />
+            ))}
           </Card.Group>
         </Container>
         <Container className={styles.newCards}>
-          <Header as="h2">New!</Header>
+          <Header as="h2">Recently Posted</Header>
           <Card.Group itemsPerRow={2}>
-            <Card
-              href="#"
-              header="Business Guide 4"
-              meta="Beginner"
-              description="Business guide one description."
-            />
-            <Card
-              href="#"
-              header="Business Guide 5"
-              meta="Beginner"
-              description="Business guide one description."
-            />
-
-            <Card
-              href="#"
-              header="Business Guide 6"
-              meta="Intermediate"
-              description="Business guide one description."
-            />
+            {guides?.slice(0, 4).map((guide, i) => (
+              <Card
+                header={`Guide ${i}`}
+                description={`${guide.Guide.substring(0, 50)}...`}
+              />
+            ))}
           </Card.Group>
         </Container>
       </Container>

--- a/app/src/components/UI/Pages/BusinessGuides.tsx
+++ b/app/src/components/UI/Pages/BusinessGuides.tsx
@@ -1,6 +1,7 @@
 import { Container, Header, Card } from "semantic-ui-react";
 import styles from "./businessGuide.module.css";
 import { useGuidesQuery } from "../../../api";
+import { Link } from "react-router-dom";
 
 // Returns the first n words of string.
 export function firstWords(s: string, numberOfSpaces: number): string {
@@ -30,10 +31,12 @@ const BusinessGuides: React.FC = () => {
           <Header as="h2">Popular</Header>
           <Card.Group itemsPerRow={2}>
             {guides?.slice(0, 4).map((guide, i) => (
-              <Card
-                header={`Guide ${i}`}
-                description={`${firstWords(guide.Guide, 15)}...`}
-              />
+              <Link to={`/guides/${guide.ID}`}>
+                <Card
+                  header={`Guide ${i}`}
+                  description={`${firstWords(guide.Guide, 15)}...`}
+                />
+              </Link>
             ))}
           </Card.Group>
         </Container>
@@ -41,10 +44,12 @@ const BusinessGuides: React.FC = () => {
           <Header as="h2">Recently Posted</Header>
           <Card.Group itemsPerRow={2}>
             {guides?.map((guide, i) => (
-              <Card
-                header={`Guide ${i}`}
-                description={`${firstWords(guide.Guide, 15)}...`}
-              />
+              <Link to={`/guides/${guide.ID}`}>
+                <Card
+                  header={`Guide ${i}`}
+                  description={`${firstWords(guide.Guide, 15)}...`}
+                />
+              </Link>
             ))}
           </Card.Group>
         </Container>

--- a/backend/api.go
+++ b/backend/api.go
@@ -1093,7 +1093,6 @@ func (a *API) DiscountDelete(c *gin.Context) {
 }
 
 func (a *API) NewChart(c *gin.Context) {
-
 	chartStars, err := a.Backend.NewChart()
 	if err != nil {
 		c.Error(err)


### PR DESCRIPTION
Closes https://github.com/bcfoodapp/streetfoodlove/issues/336.

This populates the front page with the list of guides. Ideally, each card should display the title of each guide, but we don't store that data yet.