### PR TITLE
Add resource for granting role to access place index

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -53,6 +53,7 @@ func (a *API) AddRoutes(router *gin.Engine) {
 	router.POST("/users/:id/protected", GetToken, a.UserProtectedPost)
 	router.PUT("/users/:id/protected", a.UserProtectedPut)
 	router.POST("/users/:id/s3-credentials", GetToken, a.UserS3CredentialsPost)
+	router.POST("/users/:id/location-role", GetToken, a.UserLocationRolePost)
 
 	router.GET("/reviews", a.Reviews)
 	router.GET("/reviews/:id", a.Review)
@@ -323,6 +324,16 @@ func (a *API) UserProtectedPut(c *gin.Context) {
 
 func (a *API) UserS3CredentialsPost(c *gin.Context) {
 	credentials, err := a.Backend.UserS3Credentials(c, getTokenFromContext(c))
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, credentials)
+}
+
+func (a *API) UserLocationRolePost(c *gin.Context) {
+	credentials, err := a.Backend.UserLocationRole(c, getTokenFromContext(c))
 	if err != nil {
 		c.Error(err)
 		return

--- a/backend/aws.go
+++ b/backend/aws.go
@@ -35,3 +35,18 @@ func (a *AWS) GetS3Role(ctx context.Context) (*types.Credentials, error) {
 
 	return response.Credentials, nil
 }
+
+func (a *AWS) GetLocationRole(ctx context.Context) (*types.Credentials, error) {
+	params := &sts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::907229944921:role/SFLLocationRole"),
+		RoleSessionName: aws.String("streetfoodlove"),
+		DurationSeconds: aws.Int32(900),
+	}
+
+	response, err := a.client.AssumeRole(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Credentials, nil
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -121,6 +121,15 @@ func (b *Backend) UserS3Credentials(ctx context.Context, userID uuid.UUID) (*typ
 	return b.AWS.GetS3Role(ctx)
 }
 
+// UserLocationRole returns temporary credentials which allows access to the Location service.
+func (b *Backend) UserLocationRole(ctx context.Context, userID uuid.UUID) (*types.Credentials, error) {
+	if _, err := b.Database.User(userID); err != nil {
+		return nil, err
+	}
+
+	return b.AWS.GetLocationRole(ctx)
+}
+
 func (b *Backend) Review(id uuid.UUID) (*database.Review, error) {
 	return b.Database.Review(id)
 }


### PR DESCRIPTION
`/users/:id/location-role` returns temporary credentials which can be used to access the Amazon Location Services place index. This is for the geocoding feature.